### PR TITLE
Delta lights

### DIFF
--- a/gfx_scene.h
+++ b/gfx_scene.h
@@ -193,6 +193,11 @@ struct GfxLight
     float range = FLT_MAX;
     float inner_cone_angle = 0.0f;
     float outer_cone_angle = 3.1415926535897932384626433832795f / 4.0f;
+    glm::vec3 position = glm::vec3(0.0f, 0.0f, 0.0f); //only valid for point+spot lights
+    glm::vec3 direction = glm::vec3(0.0f, 0.0f, -1.0f); //only valid for directional+spot lights
+    float range = FLT_MAX; //only valid for point+spot lights
+    float inner_cone_angle = 0.0f; //only valid for spot lights
+    float outer_cone_angle = 3.1415926535897932384626433832795f / 4.0f; //only valid for spot lights
 };
 
 GfxRef<GfxLight> gfxSceneCreateLight(GfxScene scene);


### PR DESCRIPTION
I added delta light types to gfx so they can be loaded from gltf files (obj dont support them)
The gfxLight type is currently pretty much identical to the gltf light type with respect to what data it represents. So for instance it currently only supports a single r^2 falloff parameter. If you ever wanted to add fbx scene loading or something like that later then this can be updated to have 3 falloff values (old school constant, linear and quadratic values) unless you want that support now

Lights are attached to nodes in gltf for transformation. So I still need to debug how that works so I can make sure that the lights are correctly passed through