### PR TITLE
Increase MaxNameLength

### DIFF
--- a/gfx_core.h
+++ b/gfx_core.h
@@ -52,7 +52,7 @@ enum GfxConstant
     kGfxConstant_BackBufferCount  = 3,
     kGfxConstant_MaxRenderTarget  = 4,
     kGfxConstant_MaxAnisotropy    = 8,
-    kGfxConstant_MaxNameLength    = 32,
+    kGfxConstant_MaxNameLength    = 128,
     kGfxConstant_NumBindlessSlots = 1024
 };
 


### PR DESCRIPTION
32 symbols might not be enough in some cases