### PR TITLE
Fix allow unordered access for ranges

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -5114,9 +5114,14 @@ private:
                 case Kernel::Parameter::kType_RWTexture3D:
                 case Kernel::Parameter::kType_RWTexture2DArray:
                     if(parameter.parameter_ != nullptr && parameter.id_ != parameter.parameter_->id_ &&
-                       parameter.parameter_->type_ == Program::Parameter::kType_Image &&
-                       texture_handles_.has_handle(parameter.parameter_->data_.image_.textures_->handle))
-                        ensureTextureHasUsageFlag(textures_[*parameter.parameter_->data_.image_.textures_], D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+                       parameter.parameter_->type_ == Program::Parameter::kType_Image)
+                    {
+                        for (uint32_t j = 0; j < parameter.parameter_->data_.image_.texture_count; ++j)
+                        {
+                            if (texture_handles_.has_handle(parameter.parameter_->data_.image_.textures_[j].handle))
+                                ensureTextureHasUsageFlag(textures_[parameter.parameter_->data_.image_.textures_[j]], D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+                        }
+                    }
                     break;
                 case Kernel::Parameter::kType_AccelerationStructure:
                     if(parameter.parameter_ != nullptr && parameter.id_ == parameter.parameter_->id_)


### PR DESCRIPTION
Support this case:
```
RWTexture2D<float4> g_RWAverages[6];
```

Before these changes, `ensureTextureHasUsageFlag` only processed g_RWAverages[0]. Now the whole range is processed.