### PR TITLE
Add dxcompiler and WinPix libraries as cmake targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,6 @@ add_library(gfx STATIC gfx.cpp)
 set(GFX_DXC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/third_party/dxc_2022_07_18)
 set(GFX_PIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/third_party/WinPixEventRuntime-1.0.210209001)
 
-set(GFX_DXC_PATH ${GFX_DXC_PATH} PARENT_SCOPE)
-set(GFX_PIX_PATH ${GFX_PIX_PATH} PARENT_SCOPE)
-
 target_sources(gfx PRIVATE gfx.h gfx_core.h gfx_imgui.h gfx_scene.h gfx_window.h)
 
 target_compile_options(gfx PRIVATE /bigobj)
@@ -43,9 +40,24 @@ target_compile_options(ktx      PRIVATE "/wd4244")  # '=': conversion from '__in
 target_compile_options(ktx      PRIVATE "/wd4267")  # 'initializing': conversion from 'size_t' to 'ktx_uint32_t', possible loss of data
 target_compile_options(ktx_read PRIVATE "/wd4005")
 
-target_link_libraries(gfx PUBLIC d3d12.lib dxgi.lib glm tinyobjloader ktx
-    ${GFX_DXC_PATH}/lib/x64/dxcompiler.lib
-    ${GFX_PIX_PATH}/bin/x64/WinPixEventRuntime.lib)
+add_library(dxcompiler SHARED IMPORTED)
+set_target_properties(dxcompiler PROPERTIES
+    IMPORTED_LOCATION ${GFX_DXC_PATH}/bin/x64/dxcompiler.dll
+    IMPORTED_IMPLIB ${GFX_DXC_PATH}/lib/x64/dxcompiler.lib
+)
+add_library(dxil SHARED IMPORTED)
+set_target_properties(dxil PROPERTIES
+    IMPORTED_LOCATION ${GFX_DXC_PATH}/bin/x64/dxil.dll
+    IMPORTED_IMPLIB ${GFX_DXC_PATH}/lib/x64/dxcompiler.lib
+)
+
+add_library(WinPixEventRuntime SHARED IMPORTED)
+set_target_properties(WinPixEventRuntime PROPERTIES
+    IMPORTED_LOCATION ${GFX_PIX_PATH}/bin/x64/WinPixEventRuntime.dll
+    IMPORTED_IMPLIB ${GFX_PIX_PATH}/bin/x64/WinPixEventRuntime.lib
+)
+
+target_link_libraries(gfx PUBLIC d3d12.lib dxgi.lib glm tinyobjloader ktx dxcompiler dxil WinPixEventRuntime)
 
 if(GFX_BUILD_EXAMPLES)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)


### PR DESCRIPTION
This allows for cmake to auto propagate the dependencies to any project using gfx which will then auto install the required dll's without requiring custom copy commands.