### PR TITLE
Add required compile options to cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,13 @@ target_compile_options(ktx      PRIVATE "/wd4244")  # '=': conversion from '__in
 target_compile_options(ktx      PRIVATE "/wd4267")  # 'initializing': conversion from 'size_t' to 'ktx_uint32_t', possible loss of data
 target_compile_options(ktx_read PRIVATE "/wd4005")
 
+target_compile_features(gfx PUBLIC cxx_std_14)
+target_compile_options(gfx PRIVATE
+    -DUSE_PIX
+    /W3 /WX
+    -D_HAS_EXCEPTIONS=0
+)
+
 add_library(dxcompiler SHARED IMPORTED)
 set_target_properties(dxcompiler PROPERTIES
     IMPORTED_LOCATION ${GFX_DXC_PATH}/bin/x64/dxcompiler.dll


### PR DESCRIPTION
Currently we have had some compiler flags added to the global parent project scope which are applied to all projects, gfx being one of them. However this means gfx doesnt have them on its own so I added them here.

Key additions:
- specified an default language version (set to c++14; but can easily be changed and only locally effects gfx) This provides a default but it can still be overridden by global scope
- Added the USE_PIX flag directly to gfx so PIX markers are always compiled in.
- Added exception disabling??? Not sure about this but Capsaicin had it at parent scope so I propagated it down but only to gfx (as some of the deps actually require exceptions internally)