### PR TITLE
Convert GLTF delta light values to Watts.

### DIFF
--- a/gfx_scene.h
+++ b/gfx_scene.h
@@ -1250,7 +1250,10 @@ private:
             GfxRef<GfxLight> light_ref = gfxSceneCreateLight(scene);
             GfxLight &light = *light_ref;
             light.color = glm::vec3(gltf_light.color[0], gltf_light.color[1], gltf_light.color[2]);
-            light.intensity = gltf_light.intensity;
+            float const lumens_to_watts = 683.f;
+            light.intensity             = gltf_light.intensity / lumens_to_watts;
+            if (gltf_light.type == cgltf_light_type_point || gltf_light.type == cgltf_light_type_spot)
+                light.intensity *= 4.0f * 3.1415926535897932384626433832795f;
             light.range = gltf_light.range > 0.0 ? gltf_light.range : FLT_MAX;
             light.type = gltf_light.type == cgltf_light_type_point ? kGfxLightType_Point :
                 (gltf_light.type == cgltf_light_type_spot ? kGfxLightType_Spot : kGfxLightType_Directional);


### PR DESCRIPTION
GLTF stores in lumens so must be converted. This wasnt previously needed as blender was not exporting values properly but it does now.