### PR TITLE
Allow instancing with different materials on same mesh.

### DIFF
--- a/examples/01-rtao/main.cpp
+++ b/examples/01-rtao/main.cpp
@@ -225,8 +225,8 @@ int32_t main()
         {
             GfxInstance const &instance = gfxSceneGetInstances(scene)[i];
 
-            if(instance.mesh->material)
-                gfxProgramSetParameter(gfx, rtao_program, "AlbedoBuffer", albedo_buffers[instance.mesh->material]);
+            if(instance.material)
+                gfxProgramSetParameter(gfx, rtao_program, "AlbedoBuffer", albedo_buffers[instance.material]);
             else
                 gfxProgramSetParameter(gfx, rtao_program, "AlbedoBuffer", GfxTexture());    // will return black
 

--- a/examples/common/gpu_scene.cpp
+++ b/examples/common/gpu_scene.cpp
@@ -36,6 +36,7 @@ struct Material
 struct Instance
 {
     uint32_t mesh_id;
+    uint32_t material_id;
 };
 
 struct Vertex
@@ -90,7 +91,6 @@ GpuScene UploadSceneToGpuMemory(GfxContext gfx, GfxScene scene)
         mesh.count       = (uint32_t)mesh_ref->indices.size();
         mesh.first_index = first_index;
         mesh.base_vertex = base_vertex;
-        mesh.padding     = (uint32_t)mesh_ref->material;
 
         uint32_t const mesh_id = (uint32_t)mesh_ref;
 
@@ -147,8 +147,9 @@ GpuScene UploadSceneToGpuMemory(GfxContext gfx, GfxScene scene)
     {
         GfxConstRef<GfxInstance> const instance_ref = gfxSceneGetInstanceHandle(scene, i);
 
-        Instance instance = {};
-        instance.mesh_id = (uint32_t)instance_ref->mesh;
+        Instance instance    = {};
+        instance.mesh_id     = (uint32_t)instance_ref->mesh;
+        instance.material_id = (uint32_t)instance_ref->material;
 
         uint32_t const instance_id = (uint32_t)instance_ref;
 

--- a/examples/common/gpu_scene.hlsli
+++ b/examples/common/gpu_scene.hlsli
@@ -36,12 +36,12 @@ struct Mesh
     uint count;
     uint first_index;
     uint base_vertex;
-    uint material_id;
 };
 
 struct Instance
 {
     uint mesh_id;
+    uint material_id;
 };
 
 struct Vertex

--- a/gfx_scene.h
+++ b/gfx_scene.h
@@ -1934,8 +1934,8 @@ private:
                         mesh_metadata.object_name += ".";
                         mesh_metadata.object_name += std::to_string(j);
                     }
-                    current_mesh                = mesh_ref;
-                    meshInstances[index_buffer] = mesh_ref;
+                    current_mesh                   = mesh_ref;
+                    meshInstances[position_buffer] = mesh_ref;
                 }
                 else
                 {


### PR DESCRIPTION
This moves materials from being attached to each mesh to being attached to the instance. This allows for the same mesh to be used with different materials.
The GLTF importer was updated to correctly import scenes that have this type of instancing