### PR TITLE
Add debug message callback.

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -1411,14 +1411,9 @@ public:
                                                 D3D12_MESSAGE_SEVERITY Severity, D3D12_MESSAGE_ID ID,
                                                 LPCSTR pDescription, void *pContext) {
                     if(Severity <= D3D12_MESSAGE_SEVERITY_ERROR)
-                    {
-                        GFX_PRINTLN("D3D12 Error: %s", pDescription);
-                        GFX_ASSERT(false);
-                    }
+                        GFX_ASSERTMSG(0, "D3D12 Error: %s", pDescription);
                     else if(Severity == D3D12_MESSAGE_SEVERITY_WARNING)
-                    {
                         GFX_PRINTLN("D3D12 Warning: %s", pDescription);
-                    }
                 };
                 DWORD cookie;
                 debugCallback->RegisterMessageCallback(


### PR DESCRIPTION
As it says on the tin
Errors or critical failures will trigger a debug break point while warnings will just print out the message. Any lower level information is ignored.
The message callback isnt unregistered as its used for the life time of the device anyway