### PR TITLE
Dont unbind index/vertex buffers.

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -8721,12 +8721,6 @@ private:
                 submitPipelineBarriers();
                 break;  // break barrier batches to avoid debug layer warnings
             }
-        if(*buffer.resource_state_ == D3D12_RESOURCE_STATE_INDEX_BUFFER &&  // unbind if active index buffer to prevent debug layer errors
-           buffer_handles_.has_handle(bound_index_buffer_.handle) && buffers_[bound_index_buffer_].resource_ == buffer.resource_)
-            command_list_->IASetIndexBuffer(nullptr);
-        if(*buffer.resource_state_ == D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER &&    // unbind if active vertex buffer to prevent debug layer errors
-           buffer_handles_.has_handle(bound_vertex_buffer_.handle) && buffers_[bound_vertex_buffer_].resource_ == buffer.resource_)
-            command_list_->IASetVertexBuffers(0, 1, nullptr);
         D3D12_RESOURCE_BARRIER resource_barrier = {};
         resource_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         resource_barrier.Transition.pResource = buffer.resource_;

--- a/gfx_scene.h
+++ b/gfx_scene.h
@@ -1152,7 +1152,7 @@ private:
                     animation_channel.values_[4 * next_index + 1], animation_channel.values_[4 * next_index + 2]);
                 animated_node->rotate_ = glm::slerp(previous, next, interpolate);
             }
-            if(animation_channel.type_ == kGltfAnimationChannelType_Scale)
+            else if(animation_channel.type_ == kGltfAnimationChannelType_Scale)
             {
                 for(uint32_t j = 0; j < 3; ++j)
                 {


### PR DESCRIPTION
Existing code was unbinding any index/vertex buffers if they were found in the additional parameter list. This causes draw errors when a input parameter is also the bound index/vertex buffer as previous behaviour was unbinding them just before they are needed in a draw call. The unbinding doesnt seem to be needed (comment was about debug layers but testing on both NVIDIA and AMD shows no debug warnings) so was removed.

I also fixed an error in the animation code while I was at it.