### PR TITLE
Better fix to IB/VB being used both in IA and shaders

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -8777,6 +8777,18 @@ private:
                 submitPipelineBarriers();
                 break;  // break barrier batches to avoid debug layer warnings
             }
+        if(*buffer.resource_state_ == D3D12_RESOURCE_STATE_INDEX_BUFFER &&  // unbind if active index buffer to prevent debug layer errors
+           buffer_handles_.has_handle(bound_index_buffer_.handle) && buffers_[bound_index_buffer_].resource_ == buffer.resource_)
+        {
+            command_list_->IASetIndexBuffer(nullptr);
+            force_install_index_buffer_ = true;
+        }
+        if(*buffer.resource_state_ == D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER &&    // unbind if active vertex buffer to prevent debug layer errors
+           buffer_handles_.has_handle(bound_vertex_buffer_.handle) && buffers_[bound_vertex_buffer_].resource_ == buffer.resource_)
+        {
+            command_list_->IASetVertexBuffers(0, 1, nullptr);
+            force_install_vertex_buffer_ = true;
+        }
         D3D12_RESOURCE_BARRIER resource_barrier = {};
         resource_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         resource_barrier.Transition.pResource = buffer.resource_;


### PR DESCRIPTION
This restores the changes removed in https://github.com/gboisse/gfx/pull/103 but makes sure to set `force_install_index_buffer_` and/or `force_install_vertex_buffer_` to `true`.