### PR TITLE
Set force reinstall flag when unbinding index/vertex buffers.

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -8777,6 +8777,18 @@ private:
                 submitPipelineBarriers();
                 break;  // break barrier batches to avoid debug layer warnings
             }
+        if(*buffer.resource_state_ == D3D12_RESOURCE_STATE_INDEX_BUFFER &&  // unbind if active index buffer to prevent debug layer errors
+           buffer_handles_.has_handle(bound_index_buffer_.handle) && buffers_[bound_index_buffer_].resource_ == buffer.resource_)
+        {
+            command_list_->IASetIndexBuffer(nullptr);
+            force_install_index_buffer_ = true;
+        }
+        if(*buffer.resource_state_ == D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER &&    // unbind if active vertex buffer to prevent debug layer errors
+           buffer_handles_.has_handle(bound_vertex_buffer_.handle) && buffers_[bound_vertex_buffer_].resource_ == buffer.resource_)
+        {
+            command_list_->IASetVertexBuffers(0, 1, nullptr);
+            force_install_vertex_buffer_ = true;
+        }
         D3D12_RESOURCE_BARRIER resource_barrier = {};
         resource_barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         resource_barrier.Transition.pResource = buffer.resource_;


### PR DESCRIPTION
Resurrected this as the original branch was deleted. Checked on NVIDIA and AMD cards and seems to work correctly.