### PR TITLE
Fix Validation errors

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -6029,7 +6029,7 @@ private:
             uint32_t descriptor_slot = (parameter.descriptor_slot_ != 0xFFFFFFFFu ? parameter.descriptor_slot_ :
                                                                                     dummy_descriptors_[parameter.type_]);
             if(parameter.descriptor_slot_ != 0xFFFFFFFFu)
-                initDescriptorParameter(program, invalidate_descriptors, parameter, descriptor_slot);
+                initDescriptorParameter(kernel, program, invalidate_descriptors, parameter, descriptor_slot);
             GFX_ASSERT(descriptor_slot < (descriptors_.descriptor_heap_ != nullptr ? descriptors_.descriptor_heap_->GetDesc().NumDescriptors : 0));
             if(is_compute)
                 command_list_->SetComputeRootDescriptorTable(i, descriptors_.getGPUHandle(descriptor_slot));
@@ -6084,7 +6084,7 @@ private:
                                                                 ? parameter.descriptor_slot_
                                                                 : dummy_descriptors_[parameter.type_]);
                                 if(parameter.descriptor_slot_ != 0xFFFFFFFFu)
-                                    initDescriptorParameter(program, invalidate_sbt_descriptors, parameter, descriptor_slot);
+                                    initDescriptorParameter(kernel, program, invalidate_sbt_descriptors, parameter, descriptor_slot);
                                 for(uint32_t j = 0; j < parameter.descriptor_count_; ++j)
                                 {
                                     auto descriptor_handle =
@@ -7078,7 +7078,7 @@ private:
         }
     }
 
-    void initDescriptorParameter(Program const &program, bool const invalidate_descriptors, Kernel::Parameter &parameter, uint32_t &descriptor_slot)
+    void initDescriptorParameter(Kernel const &kernel, Program const &program, bool const invalidate_descriptors, Kernel::Parameter &parameter, uint32_t &descriptor_slot)
     {
         bool const invalidate_descriptor = parameter.parameter_ != nullptr && (invalidate_descriptors || parameter.id_ != parameter.parameter_->id_);
         if(parameter.parameter_ != nullptr) parameter.id_ = parameter.parameter_->id_;
@@ -7134,7 +7134,7 @@ private:
                         Buffer &gfx_buffer = buffers_[buffer];
                         SetObjectName(gfx_buffer, buffer.name);
                         if(buffer.cpu_access == kGfxCpuAccess_None)
-                            transitionResource(gfx_buffer, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
+                            transitionResource(gfx_buffer, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                         if(!invalidate_descriptor) continue;    // already up to date
                         if(buffer.stride != GFX_ALIGN(buffer.stride, 4))
                             GFX_PRINTLN("Warning: Encountered a buffer stride of %u that isn't 4-byte aligned for parameter `%s' of program `%s/%s'; is this intentional?", buffer.stride, parameter.parameter_->name_.c_str(), program.file_path_.c_str(), program.file_name_.c_str());
@@ -7262,7 +7262,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7385,7 +7385,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7510,7 +7510,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7634,7 +7634,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -7134,7 +7134,7 @@ private:
                         Buffer &gfx_buffer = buffers_[buffer];
                         SetObjectName(gfx_buffer, buffer.name);
                         if(buffer.cpu_access == kGfxCpuAccess_None)
-                            transitionResource(gfx_buffer, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                            transitionResource(gfx_buffer, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
                         if(!invalidate_descriptor) continue;    // already up to date
                         if(buffer.stride != GFX_ALIGN(buffer.stride, 4))
                             GFX_PRINTLN("Warning: Encountered a buffer stride of %u that isn't 4-byte aligned for parameter `%s' of program `%s/%s'; is this intentional?", buffer.stride, parameter.parameter_->name_.c_str(), program.file_path_.c_str(), program.file_name_.c_str());
@@ -7262,7 +7262,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7385,7 +7385,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7510,7 +7510,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7634,7 +7634,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE);
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -4825,8 +4825,7 @@ private:
         return (value != 0 ? true : false);
     }
 
-    static inline D3D12_RESOURCE_STATES GetShaderVisibleResourceState(
-        Kernel const &kernel, Kernel::Parameter &parameter)
+    static inline D3D12_RESOURCE_STATES GetShaderVisibleResourceState(Kernel const &kernel)
     {
         return kernel.isGraphics() && kernel.ps_reflection_ != nullptr
                  ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE
@@ -7142,7 +7141,7 @@ private:
                         Buffer &gfx_buffer = buffers_[buffer];
                         SetObjectName(gfx_buffer, buffer.name);
                         if(buffer.cpu_access == kGfxCpuAccess_None)
-                            transitionResource(gfx_buffer, GetShaderVisibleResourceState(kernel, parameter));
+                            transitionResource(gfx_buffer, GetShaderVisibleResourceState(kernel));
                         if(!invalidate_descriptor) continue;    // already up to date
                         if(buffer.stride != GFX_ALIGN(buffer.stride, 4))
                             GFX_PRINTLN("Warning: Encountered a buffer stride of %u that isn't 4-byte aligned for parameter `%s' of program `%s/%s'; is this intentional?", buffer.stride, parameter.parameter_->name_.c_str(), program.file_path_.c_str(), program.file_name_.c_str());
@@ -7270,7 +7269,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7393,7 +7392,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7518,7 +7517,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7642,7 +7641,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -4825,6 +4825,14 @@ private:
         return (value != 0 ? true : false);
     }
 
+    static inline D3D12_RESOURCE_STATES GetShaderVisibleResourceState(
+        Kernel const &kernel, Kernel::Parameter &parameter)
+    {
+        return kernel.isGraphics() && kernel.ps_reflection_ != nullptr
+                 ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE
+                 : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    }
+
     uint64_t getDescriptorHeapId() const
     {
         return (static_cast<uint64_t>(descriptors_.descriptor_heap_ != nullptr ? descriptors_.descriptor_heap_->GetDesc().NumDescriptors : 0) << 32) |
@@ -7134,7 +7142,7 @@ private:
                         Buffer &gfx_buffer = buffers_[buffer];
                         SetObjectName(gfx_buffer, buffer.name);
                         if(buffer.cpu_access == kGfxCpuAccess_None)
-                            transitionResource(gfx_buffer, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                            transitionResource(gfx_buffer, GetShaderVisibleResourceState(kernel, parameter));
                         if(!invalidate_descriptor) continue;    // already up to date
                         if(buffer.stride != GFX_ALIGN(buffer.stride, 4))
                             GFX_PRINTLN("Warning: Encountered a buffer stride of %u that isn't 4-byte aligned for parameter `%s' of program `%s/%s'; is this intentional?", buffer.stride, parameter.parameter_->name_.c_str(), program.file_path_.c_str(), program.file_name_.c_str());
@@ -7262,7 +7270,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7385,7 +7393,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7510,7 +7518,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
@@ -7634,7 +7642,7 @@ private:
                             device_->CreateShaderResourceView(nullptr, &dummy_srv_desc, descriptors_.getCPUHandle(parameter.descriptor_slot_ + j));
                             continue;   // out of bounds mip level
                         }
-                        transitionResource(gfx_texture, kernel.isGraphics() && kernel.ps_reflection_ != nullptr ? D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE : D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+                        transitionResource(gfx_texture, GetShaderVisibleResourceState(kernel, parameter));
                         if(!invalidate_descriptor && gfx_texture.resource_ == parameter.bound_textures_[j])
                             continue;    // already up to date
                         D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};


### PR DESCRIPTION
This PR fixes validation errors that occur when enabling `SetEnableGPUBasedValidation`.
These errors are due to kernel parameters being default transitioned to `D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE` even though the associated kernel was compute/non-pixel shader. Changing to `D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE` fixes this for all cases I could find, however, I went 1 step further and set the transition state based on the associated kernel (this last part is in a second commit that can be reverted if desired)