### PR TITLE
Support compiling with W4 and with clang/gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,22 @@ target_include_directories(gfx PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(gfx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/D3D12MemoryAllocator/include)
 target_include_directories(gfx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/D3D12MemoryAllocator/src)
 
-target_compile_features(gfx PUBLIC cxx_std_14)
-target_compile_options(gfx PRIVATE
-    -DUSE_PIX
-    /W3 /external:anglebrackets /external:W0 /analyze:external-
-    -D_HAS_EXCEPTIONS=0
-)
+target_compile_features(gfx PUBLIC cxx_std_17)
+target_compile_definitions(gfx PRIVATE USE_PIX)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_compile_options(gfx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -pedantic -Werror>)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    target_compile_options(gfx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/W4 /WX /experimental:external /external:anglebrackets /external:W0 /analyze:external->)
+    target_compile_options(gfx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/wd4324>) # structure was padded due to alignment specifier
+    target_compile_definitions(gfx PRIVATE _HAS_EXCEPTIONS=0 _CRT_SECURE_NO_WARNINGS)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    if("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+        target_compile_options(gfx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/W4 /WX>)
+        target_compile_definitions(gfx PRIVATE _HAS_EXCEPTIONS=0 _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(gfx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -pedantic -Werror>)
+    endif()
+endif()
 
 add_library(dxcompiler SHARED IMPORTED)
 set_target_properties(dxcompiler PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,20 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     endif()
 endif()
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        target_compile_options(gfx PRIVATE -march=x86-64-v3)
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        target_compile_options(gfx PRIVATE /arch:AVX2)
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        if("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+            target_compile_options(gfx PRIVATE /arch:AVX2)
+        else()
+            target_compile_options(gfx PRIVATE -march=x86-64-v3)
+        endif()
+    endif()
+endif()
+
 add_library(dxcompiler SHARED IMPORTED)
 set_target_properties(dxcompiler PROPERTIES
     IMPORTED_LOCATION ${GFX_DXC_PATH}/bin/x64/dxcompiler.dll
@@ -107,6 +121,11 @@ if(GFX_ENABLE_SCENE)
         GIT_TAG        1.0.0
         SOURCE_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/glm/
     )
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+        set(GLM_ENABLE_SIMD_AVX2 ON CACHE BOOL "")
+    endif()
+    set(GLM_ENABLE_CXX_17 ON CACHE BOOL "")
+    set(GLM_QUIET ON CACHE BOOL "")
 
     FetchContent_Declare(
         tinyobjloader
@@ -149,13 +168,14 @@ if(GFX_ENABLE_SCENE)
 
     target_include_directories(gfx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stb)
     target_include_directories(gfx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cgltf)
-    target_include_directories(gfx PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/third_party/Vulkan-Headers/include)
+    target_include_directories(gfx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/Vulkan-Headers/include)
     target_include_directories(gfx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tinyexr)
     target_link_libraries(gfx PUBLIC glm::glm)
     target_link_libraries(gfx PRIVATE tinyobjloader ktx tinyexr)
 
     target_compile_definitions(gfx PUBLIC GFX_ENABLE_SCENE)
-	
+    target_compile_definitions(gfx PRIVATE GLM_FORCE_XYZW_ONLY)
+
     #tinyexr cmake is currently broken when not using miniz
     target_compile_definitions(tinyexr PRIVATE TINYEXR_USE_MINIZ=0 TINYEXR_USE_STB_ZLIB=1)
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -33,17 +33,18 @@ SOFTWARE.
 #include <inc/dxcapi.h>         // shader compiler
 #include <inc/d3d12shader.h>    // shader reflection
 
-#pragma warning(push)
-#pragma warning(disable:4100)   // unreferenced formal parameter
-#pragma warning(disable:4127)   // conditional expression is constant
-#pragma warning(disable:4189)   // local variable is initialized but not referenced
-#pragma warning(disable:4211)   // nonstandard extension used: redefined extern to static
+#ifdef _MSC_VER
+#   pragma warning(push)
+#   pragma warning(disable:4100)   // unreferenced formal parameter
+#   pragma warning(disable:4127)   // conditional expression is constant
+#   pragma warning(disable:4189)   // local variable is initialized but not referenced
+#   pragma warning(disable:4211)   // nonstandard extension used: redefined extern to static
+#endif
 #include <D3D12MemAlloc.cpp>    // D3D12MemoryAllocator
 #include <WinPixEventRuntime/pix3.h>
-#pragma warning(pop)
-
-#pragma warning(push)
-#pragma warning(disable:4996)   // this function or variable may be unsafe
+#ifdef _MSC_VER
+#   pragma warning(pop)
+#endif
 
 class GfxInternal
 {
@@ -8505,8 +8506,6 @@ private:
         return kGfxResult_NoError;
     }
 };
-
-#pragma warning(pop)
 
 char const *GfxInternal::shader_extensions_[] =
 {

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -33,7 +33,25 @@ SOFTWARE.
 #include <inc/dxcapi.h>         // shader compiler
 #include <inc/d3d12shader.h>    // shader reflection
 
-#ifdef _MSC_VER
+#ifdef __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#   pragma clang diagnostic ignored "-Wmisleading-indentation"
+#   pragma clang diagnostic ignored "-Wswitch"
+#   pragma clang diagnostic ignored "-Wunused-parameter"
+#   pragma clang diagnostic ignored "-Wtautological-undefined-compare"
+#   pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#   pragma clang diagnostic ignored "-Wunused-function"
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#   pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#   pragma GCC diagnostic ignored "-Wswitch"
+#   pragma GCC diagnostic ignored "-Wunused-parameter"
+#   pragma GCC diagnostic ignored "-Wtautological-undefined-compare"
+#   pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#   pragma GCC diagnostic ignored "-Wunused-function"
+#elif defined(_MSC_VER)
 #   pragma warning(push)
 #   pragma warning(disable:4100)   // unreferenced formal parameter
 #   pragma warning(disable:4127)   // conditional expression is constant
@@ -42,8 +60,12 @@ SOFTWARE.
 #endif
 #include <D3D12MemAlloc.cpp>    // D3D12MemoryAllocator
 #include <WinPixEventRuntime/pix3.h>
-#ifdef _MSC_VER
-#   pragma warning(pop)
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#    pragma warning(pop)
 #endif
 
 class GfxInternal
@@ -7090,7 +7112,7 @@ private:
         for(uint32_t i = 0; i < parameter.variable_count_; ++i)
         {
             Kernel::Parameter::Variable &variable = parameter.variables_[i];
-            if(force_update_parameter || variable.parameter_ == nullptr && variable.parameter_id_ != dispatch_id_parameter)
+            if(force_update_parameter || (variable.parameter_ == nullptr && variable.parameter_id_ != dispatch_id_parameter))
             {
                 Program::Parameters::const_iterator const it = parameters.find(variable.parameter_id_);
                 if(it != parameters.end()) variable.parameter_ = &(*it).second;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -5385,9 +5385,9 @@ private:
             {
                 D3D12_LIBRARY_DESC library_desc;
                 library->GetDesc(&library_desc);
-                for(uint32_t i = 0; i < library_desc.FunctionCount; i++)
+                for(uint32_t k = 0; k < library_desc.FunctionCount; k++)
                 {
-                    ID3D12FunctionReflection *function = library->GetFunctionByIndex(i);
+                    ID3D12FunctionReflection *function = library->GetFunctionByIndex(k);
                     D3D12_FUNCTION_DESC function_desc = {};
                     function->GetDesc(&function_desc);
                     for(uint32_t j = 0; j < function_desc.BoundResources; ++j)
@@ -5482,12 +5482,12 @@ private:
             uint32_t const space = root_signature_parameters.first;
             auto &local_root_signature_parameters = root_signature_parameters.second;
 
-            D3D12_ROOT_SIGNATURE_DESC root_signature_desc = {};
-            root_signature_desc.pParameters = local_root_signature_parameters.root_parameters.data();
-            root_signature_desc.NumParameters = (uint32_t) local_root_signature_parameters.root_parameters.size();
-            root_signature_desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE;
+            D3D12_ROOT_SIGNATURE_DESC root_signature_desc2 = {};
+            root_signature_desc2.pParameters = local_root_signature_parameters.root_parameters.data();
+            root_signature_desc2.NumParameters = (uint32_t) local_root_signature_parameters.root_parameters.size();
+            root_signature_desc2.Flags = D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE;
 
-            D3D12SerializeRootSignature(&root_signature_desc, D3D_ROOT_SIGNATURE_VERSION_1, &result, &error);
+            D3D12SerializeRootSignature(&root_signature_desc2, D3D_ROOT_SIGNATURE_VERSION_1, &result, &error);
             if(!result)
             {
                 GFX_PRINTLN("Error: Failed to serialize local root signature%s%s", error ? ":\r\n" : "", error ? (char const *)error->GetBufferPointer() : "");

--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -30,10 +30,14 @@ SOFTWARE.
 #include <ios>
 #include <fstream>
 #define CGLTF_IMPLEMENTATION
-#pragma warning(push)
-#pragma warning(disable:4789)   // buffer will be overrun
+#ifdef _MSC_VER
+#   pragma warning(push)
+#   pragma warning(disable:4789)   // buffer will be overrun
+#endif
 #include <cgltf.h>              // glTF loader
-#pragma warning(pop)
+#ifdef _MSC_VER
+#   pragma warning(pop)
+#endif
 #include <tiny_obj_loader.h>   // obj loader
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
@@ -45,9 +49,6 @@ SOFTWARE.
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtc/type_ptr.hpp>
-
-#pragma warning(push)
-#pragma warning(disable:4996)   // this function or variable may be unsafe
 
 class GfxSceneInternal
 {
@@ -2083,8 +2084,6 @@ private:
         return kGfxResult_NoError;
     }
 };
-
-#pragma warning(pop)
 
 GfxArray<GfxScene> GfxSceneInternal::scenes_;
 GfxHandles         GfxSceneInternal::scene_handles_("scene");

--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -43,7 +43,19 @@ SOFTWARE.
 #include <stb_image.h>
 #include <tinyexr.h>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
+#ifdef __clang__
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 #include <stb_image_write.h>
+#ifdef __clang__
+#   pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic pop
+#endif
 #include <ktx.h>
 #include <vulkan/vulkan.h>
 #define GLM_ENABLE_EXPERIMENTAL

--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -317,15 +317,15 @@ public:
                 GltfAnimationChannel const &channel = gltf_animation->channels_[i];
                 if(!gltf_node_handles_.has_handle(channel.node_) || (channel.type_ != kGltfAnimationChannelType_Weights)) continue;
                 GltfNode const &node = gltf_nodes_[GetObjectIndex(channel.node_)];
-                for(size_t i = 0; i < node.instances_.size(); ++i)
+                for(size_t j = 0; j < node.instances_.size(); ++j)
                 {
-                    if(!node.instances_[i]) continue;
+                    if(!node.instances_[j]) continue;
                     if(!node.default_weights_.empty())
-                        node.instances_[i]->weights = node.default_weights_;
-                    else if(!node.instances_[i]->mesh->default_weights.empty())
-                        node.instances_[i]->weights = node.instances_[i]->mesh->default_weights;
+                        node.instances_[j]->weights = node.default_weights_;
+                    else if(!node.instances_[j]->mesh->default_weights.empty())
+                        node.instances_[j]->weights = node.instances_[j]->mesh->default_weights;
                     else
-                        std::fill(node.instances_[i]->weights.begin(), node.instances_[i]->weights.end(), 0.0f);
+                        std::fill(node.instances_[j]->weights.begin(), node.instances_[j]->weights.end(), 0.0f);
                 }
             }
         }
@@ -1127,7 +1127,7 @@ private:
                         if(gfxImageIsFormatCompressed(*gfxSceneGetObject<GfxImage>(scene, (*it).second)))
                         {
                             GFX_PRINT_ERROR(kGfxResult_InvalidOperation, "Compressed textures require separate metal/roughness textures '%s'",
-                                image_metadata_[(*it).second].asset_file);
+                                image_metadata_[(*it).second].asset_file.c_str());
                             continue;
                         }
                         metallicity_map_ref = gfxSceneCreateImage(scene);
@@ -1801,11 +1801,10 @@ private:
         return kGfxResult_NoError;
     }
 
-    static inline KTX_error_code IterateKtxImage(int32_t miplevel, int32_t face, int32_t width, int32_t height, int32_t depth,
+    static inline KTX_error_code IterateKtxImage(int32_t, int32_t, int32_t, int32_t, int32_t,
         ktx_uint64_t faceLodSize, void *pixels, void *userdata)
     {
         GfxRef<GfxImage> *image_ref = (GfxRef<GfxImage> *)userdata;
-        uint64_t current_pos = (*image_ref)->data.size();
         size_t const size = (*image_ref)->data.size();
         (*image_ref)->data.resize(size + faceLodSize);
         uint8_t *back = &((*image_ref)->data[size]);
@@ -2004,7 +2003,7 @@ private:
     GfxResult importImage(GfxScene const &scene, char const *asset_file, void const *memory = nullptr, size_t size = 0)
     {
         GFX_ASSERT(asset_file != nullptr);
-        int32_t image_width, image_height, channel_count;
+        int32_t image_width = 0, image_height = 0, channel_count = 0;
         if(gfxSceneFindObjectByAssetFile<GfxImage>(scene, asset_file))
             return kGfxResult_NoError;  // image was already imported
         stbi_uc *image_data = nullptr;

--- a/gfx_scene.h
+++ b/gfx_scene.h
@@ -371,7 +371,7 @@ struct GfxVertex
 
 struct GfxJoint
 {
-    glm::uvec4 joints  = glm::uvec4(-1);
+    glm::uvec4 joints  = glm::uvec4(UINT_MAX);
     glm::vec4  weights = glm::vec4(0.0f);
 };
 

--- a/gfx_window.cpp
+++ b/gfx_window.cpp
@@ -84,12 +84,16 @@ public:
 
         if((flags & kGfxCreateWindowFlag_FullscreenWindow) != 0)
         {
-            WINDOWPLACEMENT g_wpPrev = { sizeof(g_wpPrev) };
+            WINDOWPLACEMENT g_wpPrev;
+            memset(&g_wpPrev, 0, sizeof(g_wpPrev));
+            g_wpPrev.length = sizeof(g_wpPrev);
             DWORD           dwStyle  = GetWindowLong(window_, GWL_STYLE);
 
             if((dwStyle & WS_OVERLAPPEDWINDOW) != 0)
             {
-                MONITORINFO mi = { sizeof(mi) };
+                MONITORINFO mi;
+                memset(&mi, 0, sizeof(mi));
+                mi.cbSize = sizeof(mi);
                 if(GetWindowPlacement(window_, &g_wpPrev) &&
                     GetMonitorInfo(MonitorFromWindow(window_, MONITOR_DEFAULTTOPRIMARY), &mi))
                 {


### PR DESCRIPTION
Adds support (with appropriate fixes) for compiling with error level increased from W3 to W4
Also adds support for clang-cl or mingw toolchains
Now detects X86 targets and enables AVX2 as default optimisation level (available on all Zen processors and Intel since Haswell circa 2013)