### PR TITLE
Increase max name length

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2309,7 +2309,7 @@ public:
         shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_5" : "6_0");
         Program &gfx_program = programs_.insert(program);
         gfx_program.shader_model_ = shader_model;
-        gfx_program.file_path_ = program.name;
+        gfx_program.file_path_ = name;
         gfx_program.cs_ = program_desc.cs;
         gfx_program.as_ = program_desc.as;
         gfx_program.ms_ = program_desc.ms;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2309,7 +2309,7 @@ public:
         shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_5" : "6_0");
         Program &gfx_program = programs_.insert(program);
         gfx_program.shader_model_ = shader_model;
-        gfx_program.file_path_ = name;
+        gfx_program.file_path_ = (name != nullptr) ? name : program.name;
         gfx_program.cs_ = program_desc.cs;
         gfx_program.as_ = program_desc.as;
         gfx_program.ms_ = program_desc.ms;

--- a/gfx_core.h
+++ b/gfx_core.h
@@ -52,7 +52,7 @@ enum GfxConstant
     kGfxConstant_BackBufferCount  = 3,
     kGfxConstant_MaxRenderTarget  = 8,
     kGfxConstant_MaxAnisotropy    = 8,
-    kGfxConstant_MaxNameLength    = 260,
+    kGfxConstant_MaxNameLength    = 64,
     kGfxConstant_NumBindlessSlots = 1024
 };
 

--- a/gfx_core.h
+++ b/gfx_core.h
@@ -52,7 +52,7 @@ enum GfxConstant
     kGfxConstant_BackBufferCount  = 3,
     kGfxConstant_MaxRenderTarget  = 8,
     kGfxConstant_MaxAnisotropy    = 8,
-    kGfxConstant_MaxNameLength    = 64,
+    kGfxConstant_MaxNameLength    = 260,
     kGfxConstant_NumBindlessSlots = 1024
 };
 


### PR DESCRIPTION
Increasing `kGfxConstant_MaxNameLength` up to 260 characters (`MAX_PATH` from `windows.h` header file) should fix the problem with [long shader paths](https://github.com/Radeon-Pro/Capsaicin/issues/567).
The root of the problem is `GfxProgram::name` buffer that is too small to store long paths and the full path to the shader file is truncated (for example in `GfxInternal::createProgram`).