### PR TITLE
Support additional include paths for kernels

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -317,16 +317,17 @@ struct GfxLocalRootSignatureAssociation
     char const *shader_group_name = nullptr;
 };
 
-GfxKernel gfxCreateMeshKernel(GfxContext context, GfxProgram program, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0);    // draws to back buffer
-GfxKernel gfxCreateMeshKernel(GfxContext context, GfxProgram program, GfxDrawState draw_state, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0);
-GfxKernel gfxCreateComputeKernel(GfxContext context, GfxProgram program, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0);
-GfxKernel gfxCreateGraphicsKernel(GfxContext context, GfxProgram program, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0);    // draws to back buffer
-GfxKernel gfxCreateGraphicsKernel(GfxContext context, GfxProgram program, GfxDrawState draw_state, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0);
+GfxKernel gfxCreateMeshKernel(GfxContext context, GfxProgram program, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0, char const **include_paths = nullptr, uint32_t include_path_count = 0);    // draws to back buffer
+GfxKernel gfxCreateMeshKernel(GfxContext context, GfxProgram program, GfxDrawState draw_state, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0, char const **include_paths = nullptr, uint32_t include_path_count = 0);
+GfxKernel gfxCreateComputeKernel(GfxContext context, GfxProgram program, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0, char const **include_paths = nullptr, uint32_t include_path_count = 0);
+GfxKernel gfxCreateGraphicsKernel(GfxContext context, GfxProgram program, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0, char const **include_paths = nullptr, uint32_t include_path_count = 0);    // draws to back buffer
+GfxKernel gfxCreateGraphicsKernel(GfxContext context, GfxProgram program, GfxDrawState draw_state, char const *entry_point = nullptr, char const **defines = nullptr, uint32_t define_count = 0, char const **include_paths = nullptr, uint32_t include_path_count = 0);
 GfxKernel gfxCreateRaytracingKernel(GfxContext context, GfxProgram program,
     GfxLocalRootSignatureAssociation const *local_root_signature_associations = nullptr, uint32_t local_root_signature_association_count = 0,
     char const **exports = nullptr, uint32_t export_count = 0,
     char const **subobjects = nullptr, uint32_t subobject_count = 0,
-    char const **defines = nullptr, uint32_t define_count = 0);
+    char const **defines = nullptr, uint32_t define_count = 0,
+    char const **include_paths = nullptr, uint32_t include_path_count = 0);
 GfxResult gfxDestroyKernel(GfxContext context, GfxKernel kernel);
 
 uint32_t const *gfxKernelGetNumThreads(GfxContext context, GfxKernel kernel);


### PR DESCRIPTION
Allow users to pass additional shader include search paths when creating mesh, compute, graphics or raytracing kernels.
Parameters are optional, same as with defines.