### PR TITLE
Add support for geometry instancing in DXR BVH

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2141,8 +2141,8 @@ public:
                 return cloned_raytracing_primitive; // invalid raytracing primitive type
             }
         }
-        RaytracingPrimitive const &parent_raytracing_primitive = raytracing_primitives_[raytracing_primitive];
         GfxAccelerationStructure const &acceleration_structure = getRaytracingPrimitiveAccelerationStructure(parent_raytracing_primitive);
+        RaytracingPrimitive const &parent_raytracing_primitive = raytracing_primitives_[raytracing_primitive];
         GFX_ASSERT(!isInterop(acceleration_structure)); // should never happen
         if(!acceleration_structure_handles_.has_handle(acceleration_structure.handle))
         {

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2137,7 +2137,7 @@ public:
                 raytracing_primitive = parent_raytracing_primitive.instance_.parent_;
                 break;
             default:
-                GFX_PRINT_ERROR(kGfxResult_InvalidParameter, "Cannot create a raytracing primitive using an invalid raytracing primitive object");
+                GFX_ASSERTMSG(0, "An invalid raytracing primitive type was supplied");
                 return cloned_raytracing_primitive; // invalid raytracing primitive type
             }
         }
@@ -2156,7 +2156,7 @@ public:
         for(uint32_t i = 0; i < ARRAYSIZE(gfx_raytracing_primitive.transform_); ++i)
             gfx_raytracing_primitive.transform_[i] = ((i & 3) == (i >> 2) ? 1.0f : 0.0f);
         gfx_acceleration_structure.raytracing_primitives_.push_back(cloned_raytracing_primitive);
-        gfx_raytracing_primitive.instance_id_ = raytracing_primitive.getIndex();
+        gfx_raytracing_primitive.instance_id_ = cloned_raytracing_primitive.getIndex();
         gfx_raytracing_primitive.type_ = RaytracingPrimitive::kType_Instance;
         gfx_raytracing_primitive.instance_.parent_ = raytracing_primitive;
         gfx_acceleration_structure.needs_rebuild_ = true;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2170,7 +2170,7 @@ public:
         if(!raytracing_primitive_handles_.has_handle(raytracing_primitive.handle))
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot destroy invalid raytracing primitive object");
         RaytracingPrimitive const &gfx_raytracing_primitive = raytracing_primitives_[raytracing_primitive];
-        GfxAccelerationStructure const& acceleration_structure = getRaytracingPrimitiveAccelerationStructure(gfx_raytracing_primitive);
+        GfxAccelerationStructure const &acceleration_structure = getRaytracingPrimitiveAccelerationStructure(gfx_raytracing_primitive);
         if(acceleration_structure_handles_.has_handle(acceleration_structure.handle))
             acceleration_structures_[acceleration_structure].needs_rebuild_ = true;
         collect(gfx_raytracing_primitive);  // release resources

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2141,8 +2141,8 @@ public:
                 return cloned_raytracing_primitive; // invalid raytracing primitive type
             }
         }
-        GfxAccelerationStructure const &acceleration_structure = getRaytracingPrimitiveAccelerationStructure(parent_raytracing_primitive);
         RaytracingPrimitive const &parent_raytracing_primitive = raytracing_primitives_[raytracing_primitive];
+        GfxAccelerationStructure const &acceleration_structure = getRaytracingPrimitiveAccelerationStructure(parent_raytracing_primitive);
         GFX_ASSERT(!isInterop(acceleration_structure)); // should never happen
         if(!acceleration_structure_handles_.has_handle(acceleration_structure.handle))
         {

--- a/gfx.h
+++ b/gfx.h
@@ -203,7 +203,7 @@ typedef uint32_t GfxBuildRaytracingPrimitiveFlags;
 class GfxRaytracingPrimitive { GFX_INTERNAL_NAMED_HANDLE(GfxRaytracingPrimitive); public: };
 
 GfxRaytracingPrimitive gfxCreateRaytracingPrimitive(GfxContext context, GfxAccelerationStructure acceleration_structure);
-GfxRaytracingPrimitive gfxCreateRaytracingPrimitiveInstance(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
+GfxRaytracingPrimitive gfxCreateRaytracingPrimitive(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);   // instantiates the raytracing primitive
 GfxResult gfxDestroyRaytracingPrimitive(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 
 GfxResult gfxRaytracingPrimitiveBuild(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer vertex_buffer, uint32_t vertex_stride = 0, GfxBuildRaytracingPrimitiveFlags build_flags = 0);
@@ -213,7 +213,6 @@ GfxResult gfxRaytracingPrimitiveSetInstanceID(GfxContext context, GfxRaytracingP
 GfxResult gfxRaytracingPrimitiveSetInstanceMask(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, uint8_t instance_mask);
 GfxResult gfxRaytracingPrimitiveSetInstanceContributionToHitGroupIndex(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, uint32_t instance_contribution_to_hit_group_index);
 uint64_t gfxRaytracingPrimitiveGetDataSize(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);    // in bytes
-bool gfxRaytracingPrimitiveIsInstance(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 GfxResult gfxRaytracingPrimitiveUpdate(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 GfxResult gfxRaytracingPrimitiveUpdate(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer index_buffer, GfxBuffer vertex_buffer, uint32_t vertex_stride = 0);
 
@@ -335,6 +334,10 @@ GfxResult gfxDestroyKernel(GfxContext context, GfxKernel kernel);
 uint32_t const *gfxKernelGetNumThreads(GfxContext context, GfxKernel kernel);
 GfxResult gfxKernelReloadAll(GfxContext context);   // hot-reloads all kernel objects
 
+//!
+//! Shader binding tables.
+//!
+
 class GfxSbt { GFX_INTERNAL_HANDLE(GfxSbt); public: };
 
 GfxSbt gfxCreateSbt(GfxContext context, GfxKernel const *kernels, uint32_t kernel_count, uint32_t entry_count[kGfxShaderGroupType_Count]);
@@ -365,6 +368,7 @@ GfxResult gfxCommandClearImage(GfxContext context, GfxTexture texture, uint32_t 
 
 GfxResult gfxCommandCopyTextureToBackBuffer(GfxContext context, GfxTexture texture);
 GfxResult gfxCommandCopyBufferToTexture(GfxContext context, GfxTexture dst, GfxBuffer src);
+GfxResult gfxCommandCopyBufferToCubeFace(GfxContext context, GfxTexture dst, GfxBuffer src, uint32_t face);
 GfxResult gfxCommandCopyTextureToBuffer(GfxContext context, GfxBuffer dst, GfxTexture src);
 GfxResult gfxCommandGenerateMips(GfxContext context, GfxTexture texture);   // expects mip level 0 to be populated, generates the others
 

--- a/gfx.h
+++ b/gfx.h
@@ -203,6 +203,7 @@ typedef uint32_t GfxBuildRaytracingPrimitiveFlags;
 class GfxRaytracingPrimitive { GFX_INTERNAL_NAMED_HANDLE(GfxRaytracingPrimitive); public: };
 
 GfxRaytracingPrimitive gfxCreateRaytracingPrimitive(GfxContext context, GfxAccelerationStructure acceleration_structure);
+GfxRaytracingPrimitive gfxCreateRaytracingPrimitiveInstance(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 GfxResult gfxDestroyRaytracingPrimitive(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 
 GfxResult gfxRaytracingPrimitiveBuild(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer vertex_buffer, uint32_t vertex_stride = 0, GfxBuildRaytracingPrimitiveFlags build_flags = 0);
@@ -212,6 +213,7 @@ GfxResult gfxRaytracingPrimitiveSetInstanceID(GfxContext context, GfxRaytracingP
 GfxResult gfxRaytracingPrimitiveSetInstanceMask(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, uint8_t instance_mask);
 GfxResult gfxRaytracingPrimitiveSetInstanceContributionToHitGroupIndex(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, uint32_t instance_contribution_to_hit_group_index);
 uint64_t gfxRaytracingPrimitiveGetDataSize(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);    // in bytes
+bool gfxRaytracingPrimitiveIsInstance(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 GfxResult gfxRaytracingPrimitiveUpdate(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 GfxResult gfxRaytracingPrimitiveUpdate(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer index_buffer, GfxBuffer vertex_buffer, uint32_t vertex_stride = 0);
 


### PR DESCRIPTION
Added new API function calls:
- `createRaytracingPrimitiveInstance` for creation of an instance from an existing primitive
- `raytracingPrimitiveIsInstance` to check if a primitive is an instance.

Instances don't trigger buffer destruction.
Hopefully, I didn't miss anything 