### PR TITLE
Add error message when shader file not found.

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -8381,7 +8381,11 @@ private:
             GFX_SNPRINTF(shader_file, sizeof(shader_file), "%s/%s%s", program.file_path_.c_str(), program.file_name_.c_str(), shader_extensions_[shader_type]);
             mbstowcs(wshader_file, shader_file, ARRAYSIZE(shader_file));
             // Check file existence before LoadFile call. LoadFile spams hlsl::Exception messages if file not found.
-            if(GetFileAttributesW(wshader_file) == INVALID_FILE_ATTRIBUTES) return;
+            if(GetFileAttributesW(wshader_file) == INVALID_FILE_ATTRIBUTES)
+            {
+                GFX_PRINTLN("Error: Failed to compile `%s', file not found", shader_file);
+                return;
+            }
             dxc_utils_->LoadFile(wshader_file, nullptr, &dxc_source);
             if(!dxc_source) return; // failed to load source file
             shader_source.Ptr = dxc_source->GetBufferPointer();


### PR DESCRIPTION
Currently we get a rather confusing error later on in the shader linking stage as we donet have an upfront error when the passed shader file cant be found.
So I added one.