### PR TITLE
Add High bit depth detection and support

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -963,11 +963,13 @@ public:
             output->QueryInterface(&output6);
             DXGI_OUTPUT_DESC1 output_desc;
             output6->GetDesc1(&output_desc);
-            if(output_desc.BitsPerColor > 8
-                || output_desc.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
+            if(output_desc.BitsPerColor > 8)
                 output_format = DXGI_FORMAT_R10G10B10A2_UNORM;
             /*if(output_desc.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
-                output_type = DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;*/
+            {
+                output_type = DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+                output_format = DXGI_FORMAT_R10G10B10A2_UNORM;
+            }*/
         }
 
         DXGI_SWAP_CHAIN_DESC1


### PR DESCRIPTION
Adds code to detect the current bit depth support for the connected display and sets the swapchain format accordingly. Currently it just detects 8b or 10b SDR support and automatically uses 10b if supported. This happens seamlessly and doesnt require any user changes to their app as d3d will automatically handle conversion when presenting buffers (standard float [0-1) to uint conversion).
Also added some code lines (currently commented out) that show how to detect HDR capable displays which can be used for any future HDR support updates.