### PR TITLE
Fix clearing large buffers

### DIFF
--- a/examples/02-pbr/main.cpp
+++ b/examples/02-pbr/main.cpp
@@ -36,7 +36,7 @@ char const *scene_path           = "data/SciFiHelmet/glTF/SciFiHelmet.gltf";
 
 } //! unnamed namespace
 
-int main()
+int32_t main()
 {
     GfxWindow  window = gfxCreateWindow(1280, 720, "gfx - PBR");
     GfxContext gfx    = gfxCreateContext(window);

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -3039,8 +3039,7 @@ public:
                 else
                 {
                     GfxBuffer args_buffer = allocateConstantMemory(3 * num_dispatches * sizeof(uint32_t));
-                    uint32_t *args = (uint32_t *)getBufferData(args_buffer);
-                    GFX_ASSERT(args != nullptr);
+                    uint32_t *args = (uint32_t *)getBufferData(args_buffer); GFX_ASSERT(args != nullptr);
                     for(uint32_t dispatch_index = 0; dispatch_index < num_dispatches; ++dispatch_index)
                     {
                         uint64_t const offset = (uint64_t)dispatch_index * group_size * max_num_groups;

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -1355,7 +1355,7 @@ public:
         }
 
         GfxProgramDesc clear_buffer_program_desc = {};
-        clear_buffer_program_desc.cs = "RWBuffer<uint> OutputBuffer; uint ClearValue; uint gfx_DispatchID; [numthreads(128, 1, 1)] void main(in uint gidx : SV_DispatchThreadID) { OutputBuffer[gidx + 65535 * (gfx_DispatchID << 7)] = ClearValue; }";
+        clear_buffer_program_desc.cs = "RWBuffer<uint> OutputBuffer; uint ClearValue; [numthreads(128, 1, 1)] void main(in uint gidx : SV_DispatchThreadID) { OutputBuffer[gidx] = ClearValue; }";
         clear_buffer_program_ = createProgram(clear_buffer_program_desc, "gfx_ClearBufferProgram", nullptr, nullptr, 0);
         clear_buffer_kernel_ = createComputeKernel(clear_buffer_program_, "main", nullptr, 0);
         if(!clear_buffer_kernel_)


### PR DESCRIPTION
Maximum number of groups is limited to `65535` on AMD for a given dispatch.

This was making clearing large buffers fail, this PR fixes it.
