### PR TITLE
Fix W4 compilation errors.

### DIFF
--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -2340,8 +2340,11 @@ private:
                 }
                 numDimensions = 3;
                 break;
+            default:
+                std::fclose(file);
+                return GFX_SET_ERROR(kGfxResult_InvalidOperation,
+                    "Unable to load image `%s' : Invalid dds header", asset_file);
             }
-
         }
 
         if(format == DXGI_FORMAT_UNKNOWN || format > DXGI_FORMAT_B4G4R4A4_UNORM)


### PR DESCRIPTION
Currently gfx doesnt compile when opened directly in VS using open cmake or when compiled through vscode.
This is due to differences in the way the compiler runs additional W4 checks depending on how the project is opened.