### PR TITLE
Format debug output to match visual studio diagnostic messages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ endif()
 set(GFX_DXC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/directx-dxc")
 FetchContent_Declare(
     directx-dxc
-    URL            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/dxc_2023_03_01.zip"
+    URL            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2405/dxc_2024_05_24.zip"
     SOURCE_DIR     "${GFX_DXC_PATH}"
     FIND_PACKAGE_ARGS NAMES directx-dxc
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ endif()
 set(GFX_DXC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/directx-dxc")
 FetchContent_Declare(
     directx-dxc
-    URL            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2407/dxc_2024_07_31.zip"
+    URL            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2405/dxc_2024_05_24.zip"
     SOURCE_DIR     "${GFX_DXC_PATH}"
     FIND_PACKAGE_ARGS NAMES directx-dxc
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ endif()
 set(GFX_DXC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/directx-dxc")
 FetchContent_Declare(
     directx-dxc
-    URL            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2405/dxc_2024_05_24.zip"
+    URL            "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2407/dxc_2024_07_31.zip"
     SOURCE_DIR     "${GFX_DXC_PATH}"
     FIND_PACKAGE_ARGS NAMES directx-dxc
 )

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2617,7 +2617,7 @@ public:
         char const last_char = file_path[strlen(file_path) - 1];
         char const *path_separator = (last_char == '/' || last_char == '\\' ? "" : "/");
         GFX_SNPRINTF(program.name, sizeof(program.name), "%s%s%s", file_path, path_separator, file_name);
-        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_6" : "6_0");
+        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_5" : "6_0");
         program.handle = program_handles_.allocate_handle();
         Program &gfx_program = programs_.insert(program);
         gfx_program.shader_model_ = shader_model;
@@ -2635,7 +2635,7 @@ public:
             GFX_SNPRINTF(program.name, sizeof(program.name), "%s", name);
         else
             GFX_SNPRINTF(program.name, sizeof(program.name), "gfx_Program%llu", program.handle);
-        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_6" : "6_0");
+        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_5" : "6_0");
         Program &gfx_program = programs_.insert(program);
         gfx_program.shader_model_ = shader_model;
         gfx_program.file_path_ = (name != nullptr ? name : program.name);

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -9007,6 +9007,7 @@ private:
         dxc_utils_->CreateReflection(&reflection_data, IID_PPV_ARGS(&reflection));
 
         if(shader_key != 0 && dxc_bytecode != nullptr && reflection != nullptr)
+        {
             if constexpr(std::is_same<ID3D12ShaderReflection, REFLECTION_TYPE>::value)
             {
                 GFX_ASSERT(shaders_.find(shader_key) == shaders_.end());
@@ -9026,6 +9027,7 @@ private:
                     fclose(fd); // write out reflection for shader caching
                 }
             }
+        }
         if(reflection) shader_bytecode = dxc_bytecode;
         if(!reflection) dxc_bytecode->Release();
         if(dxc_pdb_name) dxc_pdb_name->Release();

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2617,7 +2617,7 @@ public:
         char const last_char = file_path[strlen(file_path) - 1];
         char const *path_separator = (last_char == '/' || last_char == '\\' ? "" : "/");
         GFX_SNPRINTF(program.name, sizeof(program.name), "%s%s%s", file_path, path_separator, file_name);
-        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_5" : "6_0");
+        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_6" : "6_0");
         program.handle = program_handles_.allocate_handle();
         Program &gfx_program = programs_.insert(program);
         gfx_program.shader_model_ = shader_model;
@@ -2635,7 +2635,7 @@ public:
             GFX_SNPRINTF(program.name, sizeof(program.name), "%s", name);
         else
             GFX_SNPRINTF(program.name, sizeof(program.name), "gfx_Program%llu", program.handle);
-        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_5" : "6_0");
+        shader_model = (shader_model != nullptr ? shader_model : dxr_device_ != nullptr ? "6_6" : "6_0");
         Program &gfx_program = programs_.insert(program);
         gfx_program.shader_model_ = shader_model;
         gfx_program.file_path_ = (name != nullptr ? name : program.name);

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -8882,6 +8882,10 @@ private:
         shader_args.push_back(L"-I"); shader_args.push_back(L".");
         shader_args.push_back(L"-T"); shader_args.push_back(wshader_profile.data());
         shader_args.push_back(L"-HV 2021");
+        shader_args.push_back(L"-Wno-parameter-usage");
+        shader_args.push_back(L"-Wno-uninitialized");
+        shader_args.push_back(L"-Wno-conditional-uninitialized");
+        shader_args.push_back(L"-Wno-sometimes-uninitialized");
         if(experimental_shaders_)
         {
             shader_args.push_back(DXC_ARG_SKIP_VALIDATION);

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -8925,7 +8925,7 @@ private:
         if(debug_shaders_)
         {
             shader_args.push_back(DXC_ARG_DEBUG);
-            shader_args.push_back(DXC_ARG_OPTIMIZATION_LEVEL0);
+            shader_args.push_back(DXC_ARG_SKIP_OPTIMIZATIONS);
             shader_args.push_back(DXC_ARG_DEBUG_NAME_FOR_SOURCE);
         }
 

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -34,6 +34,7 @@ SOFTWARE.
 #include <d3d12shader.h>        // shader reflection
 #include <D3D12MemAlloc.h>      // D3D12 memory allocator
 #include <dxgi1_6.h>            // IDXGIFactory6 + IDXGIOutput6
+#include <filesystem>
 
 #ifdef __clang__
 #   pragma clang diagnostic push
@@ -1209,9 +1210,9 @@ public:
                                                D3D12_MESSAGE_ID, LPCSTR description, void *)
                 {
                     if(severity <= D3D12_MESSAGE_SEVERITY_ERROR)
-                        GFX_ASSERTMSG(0, "D3D12 Error: %s", description);
+                        GFX_ASSERTMSG(0, "D3D12 error: %s", description);
                     else if(severity == D3D12_MESSAGE_SEVERITY_WARNING)
-                        GFX_PRINTLN("D3D12 Warning: %s", description);
+                        GFX_PRINTLN("D3D12 warning: %s", description);
                 };
                 debug_callback->RegisterMessageCallback(callback, D3D12_MESSAGE_CALLBACK_FLAG_NONE, nullptr, &cookie);
                 debug_callback->Release();
@@ -2621,7 +2622,8 @@ public:
         Program &gfx_program = programs_.insert(program);
         gfx_program.shader_model_ = shader_model;
         gfx_program.file_name_ = file_name;
-        gfx_program.file_path_ = file_path;
+        std::string const absolute_path = absolute(std::filesystem::path(file_path)).string();
+        gfx_program.file_path_ = absolute_path.c_str();
         for(uint32_t i = 0; i < include_path_count; ++i) gfx_program.include_paths_.push_back(include_paths[i]);
         return program;
     }
@@ -8886,6 +8888,7 @@ private:
         shader_args.push_back(L"-Wno-uninitialized");
         shader_args.push_back(L"-Wno-conditional-uninitialized");
         shader_args.push_back(L"-Wno-sometimes-uninitialized");
+        shader_args.push_back(L"-fdiagnostics-format=msvc");
         if(experimental_shaders_)
         {
             shader_args.push_back(DXC_ARG_SKIP_VALIDATION);

--- a/gfx_core.h
+++ b/gfx_core.h
@@ -198,58 +198,52 @@ static inline char const *gfxResultGetString(GfxResult result)
 static inline void GFX_PRINTLN_IMPL(char const *file_name, uint32_t line_number, char const *format, ...)
 {
     va_list args;
-    char message[2048];
     va_start(args, format);
     GFX_ASSERT(file_name != nullptr);
-    uint32_t const hsize = 16, bsize = 1024;
-    uint32_t const length = (uint32_t)strlen(file_name);
-    uint32_t const offset = (length >= hsize ? (length - hsize) + 1 : 0);
-    uint32_t const start = (offset ? 0 : hsize - (length + 1));
-    char header[hsize], body[bsize]; memset(header, ' ', hsize);
-    snprintf(header + start, hsize - start, "%s", file_name + offset);
-    snprintf(body, bsize - 1, "[%s:%-4u] %s\n", header, line_number, format);
-    vsnprintf(message, sizeof(message), body, args);
-    OutputDebugStringA(message);
-    vprintf(body, args);
+    int32_t size = snprintf(nullptr, 0, "%s(%-4u): %s", file_name, line_number, format);
+    std::vector<char> body(size + 1);
+    snprintf(body.data(), body.size(), "%s(%-4u): %s", file_name, line_number, format);
+    size = vsnprintf(nullptr, 0, body.data(), args);
+    std::vector<char> message(size + 2);
+    vsnprintf(message.data(), message.size(), body.data(), args);
     va_end(args);
+    message[message.size() - 2] = '\n';
+    OutputDebugStringA(message.data());
+    puts(message.data());
 }
 
 static inline void GFX_PRINT_ERROR_IMPL(GfxResult result, char const *file_name, uint32_t line_number, char const *format, ...)
 {
     va_list args;
-    char message[2048];
     va_start(args, format);
     GFX_ASSERT(file_name != nullptr);
-    uint32_t const hsize = 16, bsize = 1024;
-    uint32_t const length = (uint32_t)strlen(file_name);
-    uint32_t const offset = (length >= hsize ? (length - hsize) + 1 : 0);
-    uint32_t const start = (offset ? 0 : hsize - (length + 1));
-    char header[hsize], body[bsize]; memset(header, ' ', hsize);
-    snprintf(header + start, hsize - start, "%s", file_name + offset);
-    snprintf(body, bsize - 1, "[%s:%-4u] Error: %s (0x%x: %s)\n", header, line_number, format, (uint32_t)result, gfxResultGetString(result));
-    vsnprintf(message, sizeof(message), body, args);
-    OutputDebugStringA(message);
-    vprintf(body, args);
+    int32_t size = snprintf(nullptr, 0, "%s(%-4u): error: %s (0x%x: %s)", file_name, line_number, format, (uint32_t)result, gfxResultGetString(result));
+    std::vector<char> body(size + 1);
+    snprintf(body.data(), body.size(), "%s(%-4u): error: %s (0x%x: %s)", file_name, line_number, format, (uint32_t)result, gfxResultGetString(result));
+    size = vsnprintf(nullptr, 0, body.data(), args);
+    std::vector<char> message(size + 2);
+    vsnprintf(message.data(), message.size(), body.data(), args);
     va_end(args);
+    message[message.size() - 2] = '\n';
+    OutputDebugStringA(message.data());
+    puts(message.data());
 }
 
 static inline GfxResult GFX_SET_ERROR_IMPL(GfxResult result, char const *file_name, uint32_t line_number, char const *format, ...)
 {
     va_list args;
-    char message[2048];
     va_start(args, format);
     GFX_ASSERT(file_name != nullptr);
-    uint32_t const hsize = 16, bsize = 1024;
-    uint32_t const length = (uint32_t)strlen(file_name);
-    uint32_t const offset = (length >= hsize ? (length - hsize) + 1 : 0);
-    uint32_t const start = (offset ? 0 : hsize - (length + 1));
-    char header[hsize], body[bsize]; memset(header, ' ', hsize);
-    snprintf(header + start, hsize - start, "%s", file_name + offset);
-    snprintf(body, bsize - 1, "[%s:%-4u] Error: %s (0x%x: %s)\n", header, line_number, format, (uint32_t)result, gfxResultGetString(result));
-    vsnprintf(message, sizeof(message), body, args);
-    OutputDebugStringA(message);
-    vprintf(body, args);
+    int32_t size = snprintf(nullptr, 0, "%s(%-4u): error: %s (0x%x: %s)", file_name, line_number, format, (uint32_t)result, gfxResultGetString(result));
+    std::vector<char> body(size + 1);
+    snprintf(body.data(), body.size(), "%s(%-4u): error: %s (0x%x: %s)", file_name, line_number, format, (uint32_t)result, gfxResultGetString(result));
+    size = vsnprintf(nullptr, 0, body.data(), args);
+    std::vector<char> message(size + 2);
+    vsnprintf(message.data(), message.size(), body.data(), args);
     va_end(args);
+    message[message.size() - 2] = '\n';
+    OutputDebugStringA(message.data());
+    puts(message.data());
     return result;
 }
 

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -250,8 +250,8 @@ public:
             }
 
             float const L = 0.0f;
-            float const R = io.DisplaySize.x;
-            float const B = io.DisplaySize.y;
+            float const R = io.DisplaySize.x / draw_data->FramebufferScale.x;
+            float const B = io.DisplaySize.y / draw_data->FramebufferScale.y;
             float const T = 0.0f;
             float const projection_matrix[4][4] =
             {
@@ -283,10 +283,10 @@ public:
                         GfxTexture const *font_buffer = (GfxTexture const *)cmd->TextureId;
                         if(font_buffer != nullptr)
                             gfxProgramSetParameter(gfx_, imgui_program_, "FontBuffer", *font_buffer);
-                        gfxCommandSetScissorRect(gfx_, (int32_t)cmd->ClipRect.x,
-                                                       (int32_t)cmd->ClipRect.y,
-                                                       (int32_t)(cmd->ClipRect.z - cmd->ClipRect.x),
-                                                       (int32_t)(cmd->ClipRect.w - cmd->ClipRect.y));
+                        gfxCommandSetScissorRect(gfx_, (int32_t)(cmd->ClipRect.x * draw_data->FramebufferScale.x),
+                                                       (int32_t)(cmd->ClipRect.y * draw_data->FramebufferScale.y),
+                                                       (int32_t)((cmd->ClipRect.z - cmd->ClipRect.x) * draw_data->FramebufferScale.x),
+                                                       (int32_t)((cmd->ClipRect.w - cmd->ClipRect.y) * draw_data->FramebufferScale.y));
                         gfxCommandDrawIndexed(gfx_, cmd->ElemCount, 1, idx_offset, vtx_offset);
                     }
                     idx_offset += cmd->ElemCount;

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -250,8 +250,8 @@ public:
             }
 
             float const L = 0.0f;
-            float const R = io.DisplaySize.x / draw_data->FramebufferScale.x;
-            float const B = io.DisplaySize.y / draw_data->FramebufferScale.y;
+            float const R = io.DisplaySize.x;
+            float const B = io.DisplaySize.y;
             float const T = 0.0f;
             float const projection_matrix[4][4] =
             {
@@ -283,10 +283,10 @@ public:
                         GfxTexture const *font_buffer = (GfxTexture const *)cmd->TextureId;
                         if(font_buffer != nullptr)
                             gfxProgramSetParameter(gfx_, imgui_program_, "FontBuffer", *font_buffer);
-                        gfxCommandSetScissorRect(gfx_, (int32_t)(cmd->ClipRect.x * draw_data->FramebufferScale.x),
-                                                       (int32_t)(cmd->ClipRect.y * draw_data->FramebufferScale.y),
-                                                       (int32_t)((cmd->ClipRect.z - cmd->ClipRect.x) * draw_data->FramebufferScale.x),
-                                                       (int32_t)((cmd->ClipRect.w - cmd->ClipRect.y) * draw_data->FramebufferScale.y));
+                        gfxCommandSetScissorRect(gfx_, (int32_t)cmd->ClipRect.x,
+                                                       (int32_t)cmd->ClipRect.y,
+                                                       (int32_t)(cmd->ClipRect.z - cmd->ClipRect.x),
+                                                       (int32_t)(cmd->ClipRect.w - cmd->ClipRect.y));
                         gfxCommandDrawIndexed(gfx_, cmd->ElemCount, 1, idx_offset, vtx_offset);
                     }
                     idx_offset += cmd->ElemCount;


### PR DESCRIPTION
This changes the format of output messages to match the format required by Visual Studio diagnostic messaging ([https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022))

This allows Visual Studio to detect the format of the messages and allows for quick navigation to the source of the message by simply double clicking the message in the output window. It also allows it to be picked up by the error window whcih can also be used for quick navigation. This works for shader compilation messages allowing for quickly traversing to the exact line and file the compilation message was generated for.

This requires a newer DXC version to support so this PR is based off of dxc-sm6.8 branch