### PR TITLE
Set agility SDK version in a single location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,11 @@ else()
 endif()
 
 set(GFX_AGILITY_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/directx12-agility")
+set(GFX_AGILITY_VERSION 615)
+target_compile_definitions(gfx PRIVATE GFX_AGILITY_VERSION=${GFX_AGILITY_VERSION})
 FetchContent_Declare(
     DirectX12-Agility
-    URL            "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.615.0"
+    URL            "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.${GFX_AGILITY_VERSION}.0"
     SOURCE_DIR     "${GFX_AGILITY_PATH}"
     FIND_PACKAGE_ARGS NAMES DirectX12-Agility
 )

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -74,7 +74,7 @@ SOFTWARE.
 
 extern "C"
 {
-__declspec(dllexport) extern const UINT D3D12SDKVersion = 615;
+__declspec(dllexport) extern const UINT     D3D12SDKVersion = GFX_AGILITY_VERSION;
 __declspec(dllexport) extern char8_t const *D3D12SDKPath = u8".\\";
 
 __declspec(dllexport) UINT GetD3D12SDKVersion()
@@ -1078,7 +1078,7 @@ public:
 
     GfxResult initializeDevice(GfxCreateContextFlags flags, IDXGIAdapter *adapter, IDXGIFactory1 *factory)
     {
-        if(GetD3D12SDKVersion() != 615)
+        if(GetD3D12SDKVersion() != GFX_AGILITY_VERSION)
             return GFX_SET_ERROR(kGfxResult_InternalError, "Agility SDK version not exported correctly");
         if((flags & kGfxCreateContextFlag_EnableDebugLayer) != 0)
         {


### PR DESCRIPTION
Uses a cmake variable to set direct3d-agility version in all used locations