### PR TITLE
Fix checking the fence value for synchronization

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -4593,7 +4593,7 @@ public:
                 {
                     GFX_TRY(resizeCallback(window_width, window_height)); // reset fence index
                 }
-                if(fences_[fence_index_]->GetCompletedValue() < fence_values_[fence_index_])
+                if(fences_[fence_index_]->GetCompletedValue() != fence_values_[fence_index_])
                 {
                     fences_[fence_index_]->SetEventOnCompletion(fence_values_[fence_index_], fence_event_);
                     WaitForSingleObject(fence_event_, INFINITE);    // wait for GPU to complete
@@ -4612,7 +4612,7 @@ public:
                 command_queue_->ExecuteCommandLists(ARRAYSIZE(command_lists), command_lists);
                 command_queue_->Signal(fences_[fence_index_], ++fence_values_[fence_index_]);
                 fence_index_ = (fence_index_ + 1) % max_frames_in_flight_;
-                if(fences_[fence_index_]->GetCompletedValue() < fence_values_[fence_index_])
+                if(fences_[fence_index_]->GetCompletedValue() != fence_values_[fence_index_])
                 {
                     fences_[fence_index_]->SetEventOnCompletion(fence_values_[fence_index_], fence_event_);
                     WaitForSingleObject(fence_event_, INFINITE);    // wait for GPU to complete
@@ -9489,7 +9489,7 @@ private:
         for(uint32_t i = 0; i < max_frames_in_flight_; ++i)
         {
             command_queue_->Signal(fences_[i], ++fence_values_[i]);
-            if(fences_[i]->GetCompletedValue() < fence_values_[i])
+            if(fences_[i]->GetCompletedValue() != fence_values_[i])
             {
                 fences_[i]->SetEventOnCompletion(fence_values_[i], fence_event_);
                 WaitForSingleObject(fence_event_, INFINITE);    // wait for GPU to complete


### PR DESCRIPTION
Previous implementation was checking the fence value using a comparison operator (not sure why), this would break if the value ever wraps around.