### PR TITLE
Update agility version to 1.616.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,11 +106,12 @@ else()
 endif()
 
 set(GFX_AGILITY_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/directx12-agility")
-set(GFX_AGILITY_VERSION 615)
+set(GFX_AGILITY_VERSION 616)
+set(GFX_AGILITY_MICRO_VERSION 0)
 target_compile_definitions(gfx PRIVATE GFX_AGILITY_VERSION=${GFX_AGILITY_VERSION})
 FetchContent_Declare(
     DirectX12-Agility
-    URL            "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.${GFX_AGILITY_VERSION}.0"
+    URL            "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.${GFX_AGILITY_VERSION}.${GFX_AGILITY_MICRO_VERSION}"
     SOURCE_DIR     "${GFX_AGILITY_PATH}"
     FIND_PACKAGE_ARGS NAMES DirectX12-Agility
 )


### PR DESCRIPTION
Main addition is OMMs, however these arent currently usable using RayQuery

[https://devblogs.microsoft.com/directx/agility-sdk-1-717-preview-and-1-616-retail/](https://devblogs.microsoft.com/directx/agility-sdk-1-717-preview-and-1-616-retail/)