### PR TITLE
Add DPI awareness

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -1837,6 +1837,11 @@ public:
         return desc;
     }
 
+    inline HWND getWindowHandle() const
+    {
+        return window_;
+    }
+
     inline bool isRaytracingSupported() const
     {
         return (dxr_device_ != nullptr ? true : false);
@@ -9853,6 +9858,13 @@ GfxDisplayDesc gfxGetDisplayDescription(GfxContext context)
     GfxInternal *gfx = GfxInternal::GetGfx(context);
     if(!gfx) return GfxDisplayDesc{};  // invalid context
     return gfx->getDisplayDescription();
+}
+
+HWND gfxGetWindowHandle(GfxContext context)
+{
+    GfxInternal *gfx = GfxInternal::GetGfx(context);
+    if(!gfx) return nullptr;    // invalid context
+    return gfx->getWindowHandle();
 }
 
 bool gfxIsRaytracingSupported(GfxContext context)

--- a/gfx.h
+++ b/gfx.h
@@ -77,6 +77,7 @@ class GfxDisplayDesc { public: inline GfxDisplayDesc() {}
 };
 
 GfxDisplayDesc gfxGetDisplayDescription(GfxContext context);
+HWND           gfxGetWindowHandle(GfxContext context);
 
 bool gfxIsRaytracingSupported(GfxContext context);
 bool gfxIsMeshShaderSupported(GfxContext context);

--- a/gfx_imgui.h
+++ b/gfx_imgui.h
@@ -41,6 +41,7 @@ GfxResult gfxImGuiInitialize(GfxContext gfx, char const **font_filenames = nullp
     ImFontConfig const *font_configs = nullptr, ImGuiConfigFlags flags = 0);
 GfxResult gfxImGuiTerminate();
 GfxResult gfxImGuiRender();
+GfxResult gfxImGuiSetDPIScale(float scale);
 
 bool gfxImGuiIsInitialized();
 

--- a/gfx_window.cpp
+++ b/gfx_window.cpp
@@ -193,6 +193,12 @@ public:
         callback_data_ = nullptr;
     }
 
+    inline float getDPIScale() const
+    {
+        UINT dpi = GetDpiForWindow(window_);
+        return (float)dpi / (float)USER_DEFAULT_SCREEN_DPI;
+    }
+
     static inline GfxWindowInternal *GetGfxWindow(GfxWindow window) { return reinterpret_cast<GfxWindowInternal *>(window.handle); }
 
 private:
@@ -378,4 +384,11 @@ bool gfxWindowUnregisterDropCallback(GfxWindow window)
     if(!gfx_window) return false; // invalid window handle
     gfx_window->unregisterDropCallback();
     return true;
+}
+
+float gfxWindowGetDPIScale(GfxWindow window)
+{
+    GfxWindowInternal *gfx_window = GfxWindowInternal::GetGfxWindow(window);
+    if(!gfx_window) return 1.0f; // invalid window handle
+    return gfx_window->getDPIScale();
 }

--- a/gfx_window.cpp
+++ b/gfx_window.cpp
@@ -46,6 +46,9 @@ class GfxWindowInternal
     bool is_previous_key_down_[VK_OEM_CLEAR] = {};
     void (*drop_callback_)(char const *, uint32_t, void *) = nullptr;
     void *callback_data_ = nullptr;
+    GfxCreateWindowFlags flags_;
+    uint32_t window_width_;
+    uint32_t window_height_;
 
 public:
     GfxWindowInternal(GfxWindow &window) { window.handle = reinterpret_cast<uint64_t>(this); }
@@ -53,6 +56,12 @@ public:
 
     GfxResult initialize(GfxWindow &window, uint32_t window_width, uint32_t window_height, char const *window_title, GfxCreateWindowFlags flags)
     {
+        flags_ = flags;
+        window_width_ = window_width;
+        window_height_ = window_height;
+
+        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
         window_title = (!window_title ? "gfx" : window_title);
 
         WNDCLASSEX
@@ -66,27 +75,24 @@ public:
 
         RegisterClassEx(&window_class);
 
-        RECT window_rect = { 0, 0, (LONG)window_width, (LONG)window_height };
-
-        DWORD const window_style = WS_OVERLAPPEDWINDOW & ~((flags & kGfxCreateWindowFlag_NoResizeWindow) != 0 ?
+        DWORD const window_style = WS_OVERLAPPEDWINDOW & ~((flags_ & kGfxCreateWindowFlag_NoResizeWindow) != 0 ?
             WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX : 0);
+        DWORD const window_style_ex = WS_EX_OVERLAPPEDWINDOW & ((flags_ & kGfxCreateWindowFlag_AcceptDrop) != 0 ? WS_EX_ACCEPTFILES : 0);
 
-        AdjustWindowRect(&window_rect, window_style, FALSE);
-
-        window_ = CreateWindowEx((flags & kGfxCreateWindowFlag_AcceptDrop) != 0 ? WS_EX_ACCEPTFILES : 0,
+        window_ = CreateWindowEx(window_style_ex,
                                  window_title,
                                  window_title,
                                  window_style,
                                  CW_USEDEFAULT,
                                  CW_USEDEFAULT,
-                                 window_rect.right - window_rect.left,
-                                 window_rect.bottom - window_rect.top,
+                                 0,
+                                 0,
                                  nullptr,
                                  nullptr,
                                  GetModuleHandle(nullptr),
                                  nullptr);
 
-        if((flags & kGfxCreateWindowFlag_FullscreenWindow) != 0)
+        if((flags_ & kGfxCreateWindowFlag_FullscreenWindow) != 0)
         {
             WINDOWPLACEMENT g_wpPrev;
             memset(&g_wpPrev, 0, sizeof(g_wpPrev));
@@ -115,12 +121,20 @@ public:
                              SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
             }
         }
+        else
+        {
+            RECT window_rect = { 0, 0, (LONG)window_width_, (LONG)window_height_ };
+            UINT dpi = GetDpiForWindow(window_);
+            AdjustWindowRectExForDpi(&window_rect, window_style, FALSE, window_style_ex, dpi);
+            SetWindowPos(window_, NULL, 0, 0, window_rect.right - window_rect.left,
+                window_rect.bottom - window_rect.top, SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE);
+        }
 
         SetWindowLongPtrA(window_, GWLP_USERDATA, (LONG_PTR)this);
 
-        ShowWindow(window_, (flags & kGfxCreateWindowFlag_MaximizeWindow) != 0 ? SW_SHOWMAXIMIZED :
-                            (flags & kGfxCreateWindowFlag_HideWindow    ) != 0 ? SW_HIDE          :
-                                                                                 SW_SHOWDEFAULT);
+        ShowWindow(window_, (flags_ & kGfxCreateWindowFlag_MaximizeWindow) != 0 ? SW_SHOWMAXIMIZED :
+                            (flags_ & kGfxCreateWindowFlag_HideWindow    ) != 0 ? SW_HIDE          :
+                                                                                  SW_SHOWDEFAULT);
 
         window.hwnd = window_;
 
@@ -131,7 +145,7 @@ public:
     {
         if(window_)
             DestroyWindow(window_);
-#    ifdef GFX_ENABLE_GUI
+#   ifdef GFX_ENABLE_GUI
         if(ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().BackendPlatformUserData != nullptr)
             ImGui_ImplWin32_Shutdown();
 #   endif
@@ -234,12 +248,15 @@ private:
             if(ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().BackendPlatformUserData == nullptr && gfxImGuiIsInitialized())
                 ImGui_ImplWin32_Init(gfx_window->window_);
 #   endif
+            SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
             switch(message)
             {
             case WM_SIZE:
                 {
-                    gfx_window->is_minimized_ = IsIconic(gfx_window->window_);
-                    gfx_window->is_maximized_ = IsZoomed(gfx_window->window_);
+                    gfx_window->is_minimized_  = IsIconic(gfx_window->window_);
+                    gfx_window->is_maximized_  = IsZoomed(gfx_window->window_);
+                    gfx_window->window_width_  = LOWORD(l_param);
+                    gfx_window->window_height_ = HIWORD(l_param);
                 }
                 break;
             case WM_DESTROY:
@@ -272,6 +289,28 @@ private:
                     DragFinish(hdrop);
                 }
                 break;
+            case WM_GETDPISCALEDSIZE:
+                {
+                    DWORD const dpi = (WORD)w_param;
+                    RECT window_rect = { 0, 0, (LONG)gfx_window->window_width_, (LONG)gfx_window->window_height_ };
+                    DWORD const window_style = WS_OVERLAPPEDWINDOW & ~((gfx_window->flags_ & kGfxCreateWindowFlag_NoResizeWindow) != 0 ?
+                                                                           WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX : 0);
+                    DWORD const window_style_ex = WS_EX_OVERLAPPEDWINDOW & ((gfx_window->flags_ & kGfxCreateWindowFlag_AcceptDrop) != 0 ? WS_EX_ACCEPTFILES : 0);
+                    AdjustWindowRectExForDpi(&window_rect, window_style, FALSE, window_style_ex, dpi);
+                    SIZE* const out = (SIZE*)l_param;
+                    out->cx = window_rect.right - window_rect.left;
+                    out->cy = window_rect.bottom - window_rect.top;
+                    return TRUE;
+                }
+#   ifdef GFX_ENABLE_GUI
+            case WM_DPICHANGED:
+                {
+                    UINT  dpi              = HIWORD(w_param);
+                    float dpi_scale_factor = (float)dpi / (float)USER_DEFAULT_SCREEN_DPI;
+                    gfxImGuiSetDPIScale(dpi_scale_factor);
+                }
+                break;
+#   endif
             case WM_CHAR:
             case WM_SETCURSOR:
             case WM_DEVICECHANGE:
@@ -286,7 +325,7 @@ private:
             case WM_XBUTTONDOWN: case WM_XBUTTONDBLCLK:
                 if(w_param < ARRAYSIZE(is_key_down_))
                     gfx_window->updateKeyBinding(message, (uint32_t)w_param);
-#    ifdef GFX_ENABLE_GUI
+#   ifdef GFX_ENABLE_GUI
                 if(ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().BackendPlatformUserData != nullptr)
                     ImGui_ImplWin32_WndProcHandler(gfx_window->window_, message, w_param, l_param);
 #   endif

--- a/gfx_window.h
+++ b/gfx_window.h
@@ -61,6 +61,7 @@ bool gfxWindowIsMinimized(GfxWindow window);
 bool gfxWindowIsMaximized(GfxWindow window);
 bool gfxWindowRegisterDropCallback(GfxWindow window, void (*callback)(char const *, uint32_t, void *), void *data = nullptr);
 bool gfxWindowUnregisterDropCallback(GfxWindow window);
+float gfxWindowGetDPIScale(GfxWindow window);
 
 #endif //! GFX_INCLUDE_GFX_WINDOW_H
 


### PR DESCRIPTION
This makes gfxWindow and gfxImgui DPI aware.

The main changes are that any application using gfxWindow will now set itself to be DPI aware and bypass windows inbuilt scaling. This results in 1:1 pixel output with windows scale artifacts on systems with scaling set to != 100%.
gfxImgui has been updated to detect DPI scaling and automatically apply the correct scale to UI elements and will detect and adapt to DPI changes at runtime.
gfxWindow will now attempt to preserve back buffer resolution across DPI changes so that if the user requests 1920x1080 then a 1920x1080 buffer will always be provided even when changing DPI at runtime. This differs from previous functionality where windows would scale the window based on the change in DPI