### PR TITLE
Fix fullscreen windows and gfxWindowToggleFullscreen

### DIFF
--- a/gfx_window.h
+++ b/gfx_window.h
@@ -62,6 +62,7 @@ bool gfxWindowIsMaximized(GfxWindow window);
 bool gfxWindowRegisterDropCallback(GfxWindow window, void (*callback)(char const *, uint32_t, void *), void *data = nullptr);
 bool gfxWindowUnregisterDropCallback(GfxWindow window);
 float gfxWindowGetDPIScale(GfxWindow window);
+void gfxWindowToggleFullscreen(GfxWindow window);
 
 #endif //! GFX_INCLUDE_GFX_WINDOW_H
 


### PR DESCRIPTION
This fixes setting fullscreen window values as well as adds a new function that allows a user to runtime toggle between fullscreen and windowed

Edit this also fixes a bug where drag and drop no longer worked correctly.