### PR TITLE
Compile D3dMemoryAllocator to use agility SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ if(GFX_ENABLE_SCENE)
     FetchContent_Declare(
         glm
         GIT_REPOSITORY https://github.com/g-truc/glm.git
-        GIT_TAG        1.0.1
+        GIT_TAG        1.0.2
         SOURCE_DIR     "${CMAKE_CURRENT_SOURCE_DIR}/third_party/glm/"
         FIND_PACKAGE_ARGS NAMES glm
     )


### PR DESCRIPTION
This modifies cmake so that the the d3dmemoryallocator gets compiled using the bundled agility sdk instead of the system d3d12 from the windows SDK. This matches compilation with gfx (which uses agility sdk) and enables newer features only provided by agility to be used by d3d12ma.

Also bumped glm to latest 1.0.2 version.