### PR TITLE
ImGui: Update backend to support requirements of imgui v1.92+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ if(GFX_ENABLE_GUI)
     FetchContent_Declare(
         imgui
         GIT_REPOSITORY https://github.com/ocornut/imgui.git
-        GIT_TAG        v1.92.6
+        GIT_TAG        v1.92.8
         SOURCE_DIR     "${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui/"
         FIND_PACKAGE_ARGS NAMES imgui
     )

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -53,15 +53,13 @@ class GfxImGuiInternal
     uint32_t const magic_ = kConstant_Magic;
 
     GfxContext gfx_ = {};
-    GfxSamplerState font_sampler_ = {};         // linear sampler (default)
+    GfxSamplerState font_sampler_linear_ = {};         // linear sampler (default)
     GfxSamplerState font_sampler_nearest_ = {}; // nearest sampler (selected via callback)
     GfxSamplerState current_sampler_ = {};      // sampler in use for the current draw
     GfxBuffer *index_buffers_ = nullptr;
     GfxBuffer *vertex_buffers_ = nullptr;
     GfxProgram imgui_program_ = {};
     GfxKernel imgui_kernel_ = {};
-    char **font_filenames_ = nullptr;
-    uint32_t font_count_ = 0;
     float dpi_scale_ = 1.0f;
 
     GfxProgram composite_program_ = {};
@@ -198,7 +196,7 @@ public:
     static void gfx_DrawCallback_SetSamplerLinear(ImDrawList const *, ImDrawCmd const *)
     {
         GfxImGuiInternal *gfx = (GfxImGuiInternal *)ImGui::GetIO().UserData;
-        gfx->current_sampler_ = gfx->font_sampler_;
+        gfx->current_sampler_ = gfx->font_sampler_linear_;
     }
 
     static void gfx_DrawCallback_SetSamplerNearest(ImDrawList const *, ImDrawCmd const *)
@@ -207,7 +205,7 @@ public:
         gfx->current_sampler_ = gfx->font_sampler_nearest_;
     }
 
-    GfxResult initialize(GfxContext const &gfx, ImGuiConfigFlags flags)
+    GfxResult initialize(GfxContext const &gfx, char const **font_filenames, uint32_t font_count, ImFontConfig const *font_configs, ImGuiConfigFlags flags)
     {
         if(!gfx)
             return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot initialize ImGui using an invalid context object");
@@ -227,6 +225,23 @@ public:
         io.DisplaySize.x = (float)gfxGetBackBufferWidth(gfx_);
         io.DisplaySize.y = (float)gfxGetBackBufferHeight(gfx_);
         io.UserData      = this; // set magic number
+
+        if(font_count > 0)
+        {
+            io.Fonts->Clear();
+            for(uint32_t i = 0; i < font_count; ++i)
+            {
+                if(i == 0 && font_configs != nullptr && font_configs[0].MergeMode)
+                {
+                    ImFontConfig defaultConfig = {};
+                    io.Fonts->AddFontDefault(&defaultConfig);
+                }
+                if(font_configs != nullptr)
+                    io.Fonts->AddFontFromFileTTF(font_filenames[i], 0, &font_configs[i]);
+                else
+                    io.Fonts->AddFontFromFileTTF(font_filenames[i], 0);
+            }
+        }
 
         ImGuiPlatformIO &platform_io = ImGui::GetPlatformIO();
         platform_io.Renderer_TextureMaxWidth = platform_io.Renderer_TextureMaxHeight = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
@@ -250,15 +265,15 @@ public:
 
         GFX_TRY(initializeKernel());
 
-        gfxDestroySamplerState(gfx_, font_sampler_);
-        font_sampler_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
+        gfxDestroySamplerState(gfx_, font_sampler_linear_);
+        font_sampler_linear_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
         gfxDestroySamplerState(gfx_, font_sampler_nearest_);
         font_sampler_nearest_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_POINT);
-        if (!font_sampler_ || !font_sampler_nearest_)
+        if (!font_sampler_linear_ || !font_sampler_nearest_)
         {
-            return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font sampler");
+            return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font samplers");
         }
-        current_sampler_ = font_sampler_;
+        current_sampler_ = font_sampler_linear_;
         GFX_TRY(gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", current_sampler_));
 
         index_buffers_ = (GfxBuffer *)gfxMalloc(gfxGetBackBufferCount(gfx_) * sizeof(GfxBuffer));
@@ -290,19 +305,9 @@ public:
             ImGui::DestroyContext();
             ImGui::SetCurrentContext(nullptr);
         }
-        if(font_count_ > 0)
-        {
-            for(uint32_t i = 0; i < font_count_; ++i)
-            {
-                gfxFree(font_filenames_[i]);
-            }
-            gfxFree(font_filenames_);
-            font_filenames_ = nullptr;
-            font_count_ = 0;
-        }
         if(gfx_)
         {
-            GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_));
+            GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_linear_));
             GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_nearest_));
             if(index_buffers_ != nullptr)
                 for(uint32_t i = 0; i < gfxGetBackBufferCount(gfx_); ++i)
@@ -336,8 +341,6 @@ public:
         ImDrawData *draw_data = ImGui::GetDrawData();
         uint32_t const buffer_index = gfxGetBackBufferIndex(gfx_);
 
-        // Catch up with texture updates. Most of the times, the list will have 1 element with an OK status, aka nothing to do.
-        // (This almost always points to ImGui::GetPlatformIO().Textures[] but is part of ImDrawData to allow overriding or disabling texture updates.)
         if(draw_data->Textures != nullptr)
             for(ImTextureData *tex : *draw_data->Textures)
                 if(tex->Status != ImTextureStatus_OK)
@@ -541,19 +544,19 @@ public:
         if (!!output_texture)
             gfxCommandBindColorTarget(gfx_, 0, output_texture);
         gfxCommandSetViewport(gfx_); // draw to render texture
-        current_sampler_ = font_sampler_;
+        current_sampler_ = font_sampler_linear_;
         gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", current_sampler_);
     }
 
     static inline GfxImGuiInternal *GetGfxImGui() { if(ImGui::GetCurrentContext() == nullptr) return nullptr; GfxImGuiInternal *gfx_imgui = static_cast<GfxImGuiInternal *>(ImGui::GetIO().UserData); return (gfx_imgui != nullptr && gfx_imgui->magic_ == kConstant_Magic ? gfx_imgui : nullptr); }
 };
 
-GfxResult gfxImGuiInitialize(GfxContext gfx, ImGuiConfigFlags flags)
+GfxResult gfxImGuiInitialize(GfxContext gfx, char const **font_filenames, uint32_t font_count, ImFontConfig const *font_configs, ImGuiConfigFlags flags)
 {
     GfxResult result;
     GfxImGuiInternal *gfx_imgui = new GfxImGuiInternal();
     if(!gfx_imgui) return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to initialize ImGui");
-    result = gfx_imgui->initialize(gfx, flags);
+    result = gfx_imgui->initialize(gfx, font_filenames, font_count, font_configs, flags);
     if(result != kGfxResult_NoError)
     {
         delete gfx_imgui;

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -62,9 +62,7 @@ class GfxImGuiInternal
     GfxKernel imgui_kernel_ = {};
     char **font_filenames_ = nullptr;
     uint32_t font_count_ = 0;
-    ImFontConfig *font_configs_ = nullptr;
     float dpi_scale_ = 1.0f;
-    bool dpi_scale_changed_  = false;
 
     GfxProgram composite_program_ = {};
     GfxKernel composite_kernel_ = {};
@@ -224,7 +222,8 @@ public:
         ImGuiIO &io = ImGui::GetIO();
         io.ConfigFlags |= flags; // config flags
         io.BackendRendererName = "imgui_impl_gfx";
-        io.BackendFlags |= ImGuiBackendFlags_RendererHasTextures; // We can honor ImGuiPlatformIO::Textures[] requests during render.
+        io.BackendFlags |= ImGuiBackendFlags_RendererHasTextures;  // We can honor ImGuiPlatformIO::Textures[] requests during render.
+        io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset; // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
         io.DisplaySize.x = (float)gfxGetBackBufferWidth(gfx_);
         io.DisplaySize.y = (float)gfxGetBackBufferHeight(gfx_);
         io.UserData      = this; // set magic number
@@ -285,7 +284,7 @@ public:
                         destroyTexture(tex);
             ImGuiIO &io = ImGui::GetIO();
             io.BackendRendererName = nullptr;
-            io.BackendFlags &= ~ImGuiBackendFlags_RendererHasTextures;
+            io.BackendFlags &= ~(ImGuiBackendFlags_RendererHasTextures | ImGuiBackendFlags_RendererHasVtxOffset);
             if(io.BackendPlatformUserData != nullptr)
                 ImGui_ImplWin32_Shutdown();
             ImGui::DestroyContext();
@@ -299,8 +298,6 @@ public:
             }
             gfxFree(font_filenames_);
             font_filenames_ = nullptr;
-            gfxFree(font_configs_);
-            font_configs_ = nullptr;
             font_count_ = 0;
         }
         if(gfx_)
@@ -433,10 +430,10 @@ public:
                                                        (int32_t)cmd->ClipRect.y,
                                                        (int32_t)(cmd->ClipRect.z - cmd->ClipRect.x),
                                                        (int32_t)(cmd->ClipRect.w - cmd->ClipRect.y));
-                        gfxCommandDrawIndexed(gfx_, cmd->ElemCount, 1, idx_offset, vtx_offset);
+                        gfxCommandDrawIndexed(gfx_, cmd->ElemCount, 1, idx_offset + cmd->IdxOffset, vtx_offset + cmd->VtxOffset);
                     }
-                    idx_offset += cmd->ElemCount;
                 }
+                idx_offset += cmd_list->IdxBuffer.Size;
                 vtx_offset += cmd_list->VtxBuffer.Size;
             }
             gfxCommandSetScissorRect(gfx_); // reset scissor test

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -143,59 +143,6 @@ public:
         return kGfxResult_NoError;
     }
 
-    GfxResult initializeScale()
-    {
-        gfxDestroySamplerState(gfx_, font_sampler_);
-
-        ImGui::StyleColorsDark();
-        ImGuiStyle &style = ImGui::GetStyle();
-        style.ScaleAllSizes(dpi_scale_);
-
-        ImGuiIO &io = ImGui::GetIO();
-        io.Fonts->Clear();
-        for(uint32_t i = 0; i < font_count_; ++i)
-        {
-            if(i == 0 && font_configs_ != nullptr && font_configs_[0].MergeMode)
-            {
-                ImFontConfig defaultConfig = {};
-                defaultConfig.SizePixels = 13.0f * dpi_scale_;
-                io.Fonts->AddFontDefault(&defaultConfig);
-            }
-            if(font_configs_ != nullptr)
-            {
-                float const pre_dpi_size = font_configs_[i].SizePixels;
-                ImVec2 const pre_dpi_glyph_offset = font_configs_[i].GlyphOffset;
-                float const pre_dpi_glyph_extra_advance_x = font_configs_[i].GlyphExtraAdvanceX;
-                float const pre_dpi_glyph_min_advance_x   = font_configs_[i].GlyphMinAdvanceX;
-                float const pre_dpi_glyph_max_advance_x   = font_configs_[i].GlyphMaxAdvanceX;
-                font_configs_[i].SizePixels *= dpi_scale_;
-                font_configs_[i].GlyphOffset.x *= dpi_scale_;
-                font_configs_[i].GlyphOffset.y *= dpi_scale_;
-                font_configs_[i].GlyphExtraAdvanceX *= dpi_scale_;
-                font_configs_[i].GlyphMinAdvanceX *= dpi_scale_;
-                font_configs_[i].GlyphMaxAdvanceX *= dpi_scale_;
-                float const font_size = (font_configs_[i].SizePixels > 0.0f) ? font_configs_[i].SizePixels : 16.0f * dpi_scale_;
-                io.Fonts->AddFontFromFileTTF(font_filenames_[i], font_size, &font_configs_[i]);
-                font_configs_[i].SizePixels = pre_dpi_size;
-                font_configs_[i].GlyphOffset = pre_dpi_glyph_offset;
-                font_configs_[i].GlyphExtraAdvanceX = pre_dpi_glyph_extra_advance_x;
-                font_configs_[i].GlyphMinAdvanceX   = pre_dpi_glyph_min_advance_x;
-                font_configs_[i].GlyphMaxAdvanceX   = pre_dpi_glyph_max_advance_x;
-            }
-            else
-            {
-                float const font_size = 16.0f * dpi_scale_;
-                io.Fonts->AddFontFromFileTTF(font_filenames_[i], font_size, nullptr);
-            }
-        }
-        font_sampler_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_POINT);
-        if(!font_sampler_)
-            return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font sampler");
-        GFX_TRY(gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", font_sampler_));
-
-        return kGfxResult_NoError;
-    }
-
     void destroyTexture(ImTextureData *tex)
     {
         GfxTexture *texture = (GfxTexture *)tex->BackendUserData;
@@ -245,7 +192,7 @@ public:
             destroyTexture(tex);
     }
 
-    GfxResult initialize(GfxContext const &gfx, char const **font_filenames, uint32_t font_count, ImFontConfig const *font_configs, ImGuiConfigFlags flags)
+    GfxResult initialize(GfxContext const &gfx, ImGuiConfigFlags flags)
     {
         if(!gfx)
             return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot initialize ImGui using an invalid context object");
@@ -267,25 +214,6 @@ public:
         io.DisplaySize.y = (float)gfxGetBackBufferHeight(gfx_);
         io.UserData = this; // set magic number
 
-        if(font_count > 0)
-        {
-            font_filenames_ = (char **)gfxMalloc(font_count * sizeof(char *));
-            font_count_     = font_count;
-            for(uint32_t i = 0; i < font_count; ++i)
-            {
-                font_filenames_[i] = (char *)gfxMalloc(strlen(font_filenames[i]) + 1);
-                strcpy(font_filenames_[i], font_filenames[i]);
-            }
-            if(font_configs != nullptr)
-            {
-                font_configs_ = (ImFontConfig *)gfxMalloc(font_count * sizeof(ImFontConfig));
-                for(uint32_t i = 0; i < font_count; ++i)
-                {
-                    font_configs_[i] = font_configs[i];
-                }
-            }
-        }
-
         HWND window = gfxGetWindowHandle(gfx_);
         dpi_scale_ = 1.0f;
         if(window != nullptr)
@@ -293,8 +221,22 @@ public:
             UINT dpi = GetDpiForWindow(window);
             dpi_scale_ = (float)dpi / (float)USER_DEFAULT_SCREEN_DPI;
         }
+
+        ImGui::StyleColorsDark();
+        ImGuiStyle &style = ImGui::GetStyle();
+        style.ScaleAllSizes(dpi_scale_);
+        style.FontScaleDpi = dpi_scale_;
+        io.DisplayFramebufferScale = ImVec2(dpi_scale_, dpi_scale_);
+
         GFX_TRY(initializeKernel());
-        GFX_TRY(initializeScale());
+
+        gfxDestroySamplerState(gfx_, font_sampler_);
+        font_sampler_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_POINT);
+        if (!font_sampler_)
+        {
+            return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font sampler");
+        }
+        GFX_TRY(gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", font_sampler_));
 
         index_buffers_ = (GfxBuffer *)gfxMalloc(gfxGetBackBufferCount(gfx_) * sizeof(GfxBuffer));
         vertex_buffers_ = (GfxBuffer *)gfxMalloc(gfxGetBackBufferCount(gfx_) * sizeof(GfxBuffer));
@@ -371,12 +313,6 @@ public:
         ImGui::Render();    // implicit ImGui::EndFrame()
         ImDrawData *draw_data = ImGui::GetDrawData();
         uint32_t const buffer_index = gfxGetBackBufferIndex(gfx_);
-
-        if(dpi_scale_changed_)
-        {
-            GFX_TRY(initializeScale());
-            dpi_scale_changed_ = false;
-        }
 
         // Catch up with texture updates. Most of the times, the list will have 1 element with an OK status, aka nothing to do.
         // (This almost always points to ImGui::GetPlatformIO().Textures[] but is part of ImDrawData to allow overriding or disabling texture updates.)
@@ -479,6 +415,7 @@ public:
         ImGui_ImplWin32_NewFrame();
         io.DisplaySize.x = (float)gfxGetBackBufferWidth(gfx_);
         io.DisplaySize.y = (float)gfxGetBackBufferHeight(gfx_);
+        io.DisplayFramebufferScale = ImVec2(dpi_scale_, dpi_scale_);
         ImGui::NewFrame();  // can start recording new commands again
 
         return kGfxResult_NoError;
@@ -563,20 +500,21 @@ public:
 
     void setDPIScale(float scale)
     {
-        dpi_scale_changed_ = true;
+        ImGuiStyle &style = ImGui::GetStyle();
+        style.ScaleAllSizes(scale / dpi_scale_);
+        style.FontScaleDpi = dpi_scale_;
         dpi_scale_         = scale;
     }
 
     static inline GfxImGuiInternal *GetGfxImGui() { if(ImGui::GetCurrentContext() == nullptr) return nullptr; GfxImGuiInternal *gfx_imgui = static_cast<GfxImGuiInternal *>(ImGui::GetIO().UserData); return (gfx_imgui != nullptr && gfx_imgui->magic_ == kConstant_Magic ? gfx_imgui : nullptr); }
 };
 
-GfxResult gfxImGuiInitialize(GfxContext gfx, char const **font_filenames, uint32_t font_count,
-    ImFontConfig const *font_configs, ImGuiConfigFlags flags)
+GfxResult gfxImGuiInitialize(GfxContext gfx, ImGuiConfigFlags flags)
 {
     GfxResult result;
     GfxImGuiInternal *gfx_imgui = new GfxImGuiInternal();
     if(!gfx_imgui) return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to initialize ImGui");
-    result = gfx_imgui->initialize(gfx, font_filenames, font_count, font_configs, flags);
+    result = gfx_imgui->initialize(gfx, flags);
     if(result != kGfxResult_NoError)
     {
         delete gfx_imgui;

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -53,7 +53,9 @@ class GfxImGuiInternal
     uint32_t const magic_ = kConstant_Magic;
 
     GfxContext gfx_ = {};
-    GfxSamplerState font_sampler_ = {};
+    GfxSamplerState font_sampler_ = {};         // nearest sampler (default)
+    GfxSamplerState font_sampler_linear_ = {};  // linear sampler (selected via callback)
+    GfxSamplerState current_sampler_ = {};      // sampler in use for the current draw
     GfxBuffer *index_buffers_ = nullptr;
     GfxBuffer *vertex_buffers_ = nullptr;
     GfxProgram imgui_program_ = {};
@@ -192,6 +194,21 @@ public:
             destroyTexture(tex);
     }
 
+    // Draw callbacks
+    static void gfx_DrawCallback_ResetRenderState(ImDrawList const *, ImDrawCmd const *) {}
+
+    static void gfx_DrawCallback_SetSamplerLinear(ImDrawList const *, ImDrawCmd const *)
+    {
+        GfxImGuiInternal *gfx = (GfxImGuiInternal *)ImGui::GetIO().UserData;
+        gfx->current_sampler_ = gfx->font_sampler_linear_;
+    }
+
+    static void gfx_DrawCallback_SetSamplerNearest(ImDrawList const *, ImDrawCmd const *)
+    {
+        GfxImGuiInternal *gfx = (GfxImGuiInternal *)ImGui::GetIO().UserData;
+        gfx->current_sampler_ = gfx->font_sampler_;
+    }
+
     GfxResult initialize(GfxContext const &gfx, ImGuiConfigFlags flags)
     {
         if(!gfx)
@@ -208,11 +225,15 @@ public:
         io.ConfigFlags |= flags; // config flags
         io.BackendRendererName = "imgui_impl_gfx";
         io.BackendFlags |= ImGuiBackendFlags_RendererHasTextures; // We can honor ImGuiPlatformIO::Textures[] requests during render.
-        ImGuiPlatformIO &platform_io = ImGui::GetPlatformIO();
-        platform_io.Renderer_TextureMaxWidth = platform_io.Renderer_TextureMaxHeight = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
         io.DisplaySize.x = (float)gfxGetBackBufferWidth(gfx_);
         io.DisplaySize.y = (float)gfxGetBackBufferHeight(gfx_);
-        io.UserData = this; // set magic number
+        io.UserData      = this; // set magic number
+
+        ImGuiPlatformIO &platform_io = ImGui::GetPlatformIO();
+        platform_io.Renderer_TextureMaxWidth = platform_io.Renderer_TextureMaxHeight = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
+        platform_io.DrawCallback_ResetRenderState  = gfx_DrawCallback_ResetRenderState;
+        platform_io.DrawCallback_SetSamplerLinear  = gfx_DrawCallback_SetSamplerLinear;
+        platform_io.DrawCallback_SetSamplerNearest = gfx_DrawCallback_SetSamplerNearest;
 
         HWND window = gfxGetWindowHandle(gfx_);
         dpi_scale_ = 1.0f;
@@ -232,11 +253,14 @@ public:
 
         gfxDestroySamplerState(gfx_, font_sampler_);
         font_sampler_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_POINT);
-        if (!font_sampler_)
+        gfxDestroySamplerState(gfx_, font_sampler_linear_);
+        font_sampler_linear_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
+        if (!font_sampler_ || !font_sampler_linear_)
         {
             return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font sampler");
         }
-        GFX_TRY(gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", font_sampler_));
+        current_sampler_ = font_sampler_;
+        GFX_TRY(gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", current_sampler_));
 
         index_buffers_ = (GfxBuffer *)gfxMalloc(gfxGetBackBufferCount(gfx_) * sizeof(GfxBuffer));
         vertex_buffers_ = (GfxBuffer *)gfxMalloc(gfxGetBackBufferCount(gfx_) * sizeof(GfxBuffer));
@@ -282,6 +306,7 @@ public:
         if(gfx_)
         {
             GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_));
+            GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_linear_));
             if(index_buffers_ != nullptr)
                 for(uint32_t i = 0; i < gfxGetBackBufferCount(gfx_); ++i)
                 {
@@ -376,12 +401,7 @@ public:
             };
             gfxProgramSetParameter(gfx_, imgui_program_, "ProjectionMatrix", projection_matrix);
 
-            gfxCommandBindKernel(gfx_, imgui_kernel_);
-            gfxCommandBindIndexBuffer(gfx_, index_buffer);
-            gfxCommandBindVertexBuffer(gfx_, vertex_buffer);
-            if (!!output_texture)
-                gfxCommandBindColorTarget(gfx_, 0, output_texture);
-            gfxCommandSetViewport(gfx_); // draw to render texture
+            setupRenderState(index_buffer, vertex_buffer, output_texture);
 
             int32_t vtx_offset = 0;
             int32_t idx_offset = 0;
@@ -392,13 +412,23 @@ public:
                 {
                     ImDrawCmd const *cmd = &cmd_list->CmdBuffer[j];
                     if(cmd->UserCallback)
-                        cmd->UserCallback(cmd_list, cmd);
+                    {
+                        // ImDrawCallback_ResetRenderState is a special sentinel value used by imgui
+                        // to request the renderer to reset its render state.
+                        if(cmd->UserCallback == ImDrawCallback_ResetRenderState)
+                            setupRenderState(index_buffer, vertex_buffer, output_texture);
+                        else
+                            cmd->UserCallback(cmd_list, cmd);
+                    }
                     else if(cmd->ClipRect.x != cmd->ClipRect.z &&
                             cmd->ClipRect.y != cmd->ClipRect.w)
                     {
                         GfxTexture const *font_buffer = (GfxTexture const *)cmd->GetTexID();
                         if(font_buffer != nullptr)
                             gfxProgramSetParameter(gfx_, imgui_program_, "FontBuffer", *font_buffer);
+                        // Re-bind sampler each draw so callback-driven sampler changes (e.g.
+                        // gfxImGuiDrawCallback_SetSamplerLinear) take effect on subsequent draws.
+                        gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", current_sampler_);
                         gfxCommandSetScissorRect(gfx_, (int32_t)cmd->ClipRect.x,
                                                        (int32_t)cmd->ClipRect.y,
                                                        (int32_t)(cmd->ClipRect.z - cmd->ClipRect.x),
@@ -504,6 +534,18 @@ public:
         style.ScaleAllSizes(scale / dpi_scale_);
         style.FontScaleDpi = dpi_scale_;
         dpi_scale_         = scale;
+    }
+
+    void setupRenderState(GfxBuffer const &index_buffer, GfxBuffer const &vertex_buffer, GfxTexture const &output_texture)
+    {
+        gfxCommandBindKernel(gfx_, imgui_kernel_);
+        gfxCommandBindIndexBuffer(gfx_, index_buffer);
+        gfxCommandBindVertexBuffer(gfx_, vertex_buffer);
+        if (!!output_texture)
+            gfxCommandBindColorTarget(gfx_, 0, output_texture);
+        gfxCommandSetViewport(gfx_); // draw to render texture
+        current_sampler_ = font_sampler_;
+        gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", current_sampler_);
     }
 
     static inline GfxImGuiInternal *GetGfxImGui() { if(ImGui::GetCurrentContext() == nullptr) return nullptr; GfxImGuiInternal *gfx_imgui = static_cast<GfxImGuiInternal *>(ImGui::GetIO().UserData); return (gfx_imgui != nullptr && gfx_imgui->magic_ == kConstant_Magic ? gfx_imgui : nullptr); }

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -53,8 +53,8 @@ class GfxImGuiInternal
     uint32_t const magic_ = kConstant_Magic;
 
     GfxContext gfx_ = {};
-    GfxSamplerState font_sampler_ = {};         // nearest sampler (default)
-    GfxSamplerState font_sampler_linear_ = {};  // linear sampler (selected via callback)
+    GfxSamplerState font_sampler_ = {};         // linear sampler (default)
+    GfxSamplerState font_sampler_nearest_ = {}; // nearest sampler (selected via callback)
     GfxSamplerState current_sampler_ = {};      // sampler in use for the current draw
     GfxBuffer *index_buffers_ = nullptr;
     GfxBuffer *vertex_buffers_ = nullptr;
@@ -198,13 +198,13 @@ public:
     static void gfx_DrawCallback_SetSamplerLinear(ImDrawList const *, ImDrawCmd const *)
     {
         GfxImGuiInternal *gfx = (GfxImGuiInternal *)ImGui::GetIO().UserData;
-        gfx->current_sampler_ = gfx->font_sampler_linear_;
+        gfx->current_sampler_ = gfx->font_sampler_;
     }
 
     static void gfx_DrawCallback_SetSamplerNearest(ImDrawList const *, ImDrawCmd const *)
     {
         GfxImGuiInternal *gfx = (GfxImGuiInternal *)ImGui::GetIO().UserData;
-        gfx->current_sampler_ = gfx->font_sampler_;
+        gfx->current_sampler_ = gfx->font_sampler_nearest_;
     }
 
     GfxResult initialize(GfxContext const &gfx, ImGuiConfigFlags flags)
@@ -251,10 +251,10 @@ public:
         GFX_TRY(initializeKernel());
 
         gfxDestroySamplerState(gfx_, font_sampler_);
-        font_sampler_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_POINT);
-        gfxDestroySamplerState(gfx_, font_sampler_linear_);
-        font_sampler_linear_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
-        if (!font_sampler_ || !font_sampler_linear_)
+        font_sampler_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_LINEAR);
+        gfxDestroySamplerState(gfx_, font_sampler_nearest_);
+        font_sampler_nearest_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_POINT);
+        if (!font_sampler_ || !font_sampler_nearest_)
         {
             return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font sampler");
         }
@@ -303,7 +303,7 @@ public:
         if(gfx_)
         {
             GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_));
-            GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_linear_));
+            GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_nearest_));
             if(index_buffers_ != nullptr)
                 for(uint32_t i = 0; i < gfxGetBackBufferCount(gfx_); ++i)
                 {
@@ -529,8 +529,8 @@ public:
     {
         ImGuiStyle &style = ImGui::GetStyle();
         style.ScaleAllSizes(scale / dpi_scale_);
-        style.FontScaleDpi = dpi_scale_;
         dpi_scale_         = scale;
+        style.FontScaleDpi = dpi_scale_;
     }
 
     void setupRenderState(GfxBuffer const &index_buffer, GfxBuffer const &vertex_buffer, GfxTexture const &output_texture)

--- a/gfx_imgui.cpp
+++ b/gfx_imgui.cpp
@@ -53,7 +53,6 @@ class GfxImGuiInternal
     uint32_t const magic_ = kConstant_Magic;
 
     GfxContext gfx_ = {};
-    GfxTexture font_buffer_ = {};
     GfxSamplerState font_sampler_ = {};
     GfxBuffer *index_buffers_ = nullptr;
     GfxBuffer *vertex_buffers_ = nullptr;
@@ -146,7 +145,6 @@ public:
 
     GfxResult initializeScale()
     {
-        gfxDestroyTexture(gfx_, font_buffer_);
         gfxDestroySamplerState(gfx_, font_sampler_);
 
         ImGui::StyleColorsDark();
@@ -190,24 +188,61 @@ public:
                 io.Fonts->AddFontFromFileTTF(font_filenames_[i], font_size, nullptr);
             }
         }
-        uint8_t *font_data;
-        int32_t font_width, font_height;
-        io.Fonts->GetTexDataAsRGBA32(&font_data, &font_width, &font_height);
-        GfxBuffer font_buffer = gfxCreateBuffer(gfx_, font_width * font_height * 4, font_data, kGfxCpuAccess_Write);
-        font_buffer_ = gfxCreateTexture2D(gfx_, font_width, font_height, DXGI_FORMAT_R8G8B8A8_UNORM);
         font_sampler_ = gfxCreateSamplerState(gfx_, D3D12_FILTER_MIN_MAG_MIP_POINT);
-        if(!font_buffer || !font_buffer_ || !font_sampler_)
-        {
-            gfxDestroyBuffer(gfx_, font_buffer);
-            return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font buffer");
-        }
-        font_buffer_.setName("gfx_ImGuiFontBuffer");
-        io.Fonts->TexRef = (ImTextureID)&font_buffer_;
-        GFX_TRY(gfxCommandCopyBufferToTexture(gfx_, font_buffer_, font_buffer));
-        GFX_TRY(gfxDestroyBuffer(gfx_, font_buffer));
+        if(!font_sampler_)
+            return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create ImGui font sampler");
         GFX_TRY(gfxProgramSetParameter(gfx_, imgui_program_, "FontSampler", font_sampler_));
 
         return kGfxResult_NoError;
+    }
+
+    void destroyTexture(ImTextureData *tex)
+    {
+        GfxTexture *texture = (GfxTexture *)tex->BackendUserData;
+        if(texture == nullptr)
+            return;
+        gfxDestroyTexture(gfx_, *texture);
+        delete texture;
+        tex->SetTexID(ImTextureID_Invalid);
+        tex->SetStatus(ImTextureStatus_Destroyed);
+        tex->BackendUserData = nullptr;
+    }
+
+    void updateTexture(ImTextureData *tex)
+    {
+        if(tex->Status == ImTextureStatus_WantCreate)
+        {
+            IM_ASSERT(tex->TexID == ImTextureID_Invalid && tex->BackendUserData == nullptr);
+            IM_ASSERT(tex->Format == ImTextureFormat_RGBA32);
+            GfxTexture *texture = new GfxTexture();
+            *texture = gfxCreateTexture2D(gfx_, (uint32_t)tex->Width, (uint32_t)tex->Height, DXGI_FORMAT_R8G8B8A8_UNORM);
+            if(!*texture)
+            {
+                delete texture;
+                return;
+            }
+            texture->setName("gfx_ImGuiTexture");
+            uint64_t const size = (uint64_t)tex->GetPitch() * (uint64_t)tex->Height;
+            GfxBuffer upload_buffer = gfxCreateBuffer(gfx_, size, tex->GetPixels(), kGfxCpuAccess_Write);
+            gfxCommandCopyBufferToTexture(gfx_, *texture, upload_buffer);
+            gfxDestroyBuffer(gfx_, upload_buffer);
+            tex->SetTexID((ImTextureID)(intptr_t)texture);
+            tex->SetStatus(ImTextureStatus_OK);
+            tex->BackendUserData = texture;
+        }
+        else if(tex->Status == ImTextureStatus_WantUpdates)
+        {
+            // gfx has no partial texture update path; re-upload the full texture.
+            GfxTexture *texture = (GfxTexture *)tex->BackendUserData;
+            IM_ASSERT(texture != nullptr);
+            uint64_t const size = (uint64_t)tex->GetPitch() * (uint64_t)tex->Height;
+            GfxBuffer upload_buffer = gfxCreateBuffer(gfx_, size, tex->GetPixels(), kGfxCpuAccess_Write);
+            gfxCommandCopyBufferToTexture(gfx_, *texture, upload_buffer);
+            gfxDestroyBuffer(gfx_, upload_buffer);
+            tex->SetStatus(ImTextureStatus_OK);
+        }
+        if(tex->Status == ImTextureStatus_WantDestroy && tex->UnusedFrames > 0)
+            destroyTexture(tex);
     }
 
     GfxResult initialize(GfxContext const &gfx, char const **font_filenames, uint32_t font_count, ImFontConfig const *font_configs, ImGuiConfigFlags flags)
@@ -224,6 +259,10 @@ public:
         ImGui::StyleColorsDark();
         ImGuiIO &io = ImGui::GetIO();
         io.ConfigFlags |= flags; // config flags
+        io.BackendRendererName = "imgui_impl_gfx";
+        io.BackendFlags |= ImGuiBackendFlags_RendererHasTextures; // We can honor ImGuiPlatformIO::Textures[] requests during render.
+        ImGuiPlatformIO &platform_io = ImGui::GetPlatformIO();
+        platform_io.Renderer_TextureMaxWidth = platform_io.Renderer_TextureMaxHeight = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
         io.DisplaySize.x = (float)gfxGetBackBufferWidth(gfx_);
         io.DisplaySize.y = (float)gfxGetBackBufferHeight(gfx_);
         io.UserData = this; // set magic number
@@ -273,7 +312,15 @@ public:
     {
         if(ImGui::GetCurrentContext() != nullptr)
         {
-            if(ImGui::GetIO().BackendPlatformUserData != nullptr)
+            // Destroy all dynamic textures owned by the backend before tearing down the context.
+            if(gfx_)
+                for(ImTextureData *tex : ImGui::GetPlatformIO().Textures)
+                    if(tex->RefCount == 1)
+                        destroyTexture(tex);
+            ImGuiIO &io = ImGui::GetIO();
+            io.BackendRendererName = nullptr;
+            io.BackendFlags &= ~ImGuiBackendFlags_RendererHasTextures;
+            if(io.BackendPlatformUserData != nullptr)
                 ImGui_ImplWin32_Shutdown();
             ImGui::DestroyContext();
             ImGui::SetCurrentContext(nullptr);
@@ -292,7 +339,6 @@ public:
         }
         if(gfx_)
         {
-            GFX_TRY(gfxDestroyTexture(gfx_, font_buffer_));
             GFX_TRY(gfxDestroySamplerState(gfx_, font_sampler_));
             if(index_buffers_ != nullptr)
                 for(uint32_t i = 0; i < gfxGetBackBufferCount(gfx_); ++i)
@@ -323,7 +369,7 @@ public:
             GFX_SET_ERROR(kGfxResult_InvalidParameter, "ImGui can only composite to sRGB render targets");
         ImGuiIO &io = ImGui::GetIO();
         ImGui::Render();    // implicit ImGui::EndFrame()
-        ImDrawData const *draw_data = ImGui::GetDrawData();
+        ImDrawData *draw_data = ImGui::GetDrawData();
         uint32_t const buffer_index = gfxGetBackBufferIndex(gfx_);
 
         if(dpi_scale_changed_)
@@ -331,6 +377,13 @@ public:
             GFX_TRY(initializeScale());
             dpi_scale_changed_ = false;
         }
+
+        // Catch up with texture updates. Most of the times, the list will have 1 element with an OK status, aka nothing to do.
+        // (This almost always points to ImGui::GetPlatformIO().Textures[] but is part of ImDrawData to allow overriding or disabling texture updates.)
+        if(draw_data->Textures != nullptr)
+            for(ImTextureData *tex : *draw_data->Textures)
+                if(tex->Status != ImTextureStatus_OK)
+                    updateTexture(tex);
 
         if(draw_data->TotalVtxCount > 0)
         {

--- a/gfx_imgui.h
+++ b/gfx_imgui.h
@@ -37,8 +37,7 @@ SOFTWARE.
 //! ImGui initialization/termination.
 //!
 
-GfxResult gfxImGuiInitialize(GfxContext gfx, char const **font_filenames = nullptr, uint32_t font_count = 0,
-    ImFontConfig const *font_configs = nullptr, ImGuiConfigFlags flags = 0);
+GfxResult gfxImGuiInitialize(GfxContext gfx, ImGuiConfigFlags flags = 0);
 GfxResult gfxImGuiTerminate();
 GfxResult gfxImGuiRender(GfxTexture output_texture = {});
 GfxResult gfxImGuiComposite(GfxTexture color_texture, GfxTexture imgui_texture);

--- a/gfx_imgui.h
+++ b/gfx_imgui.h
@@ -37,7 +37,7 @@ SOFTWARE.
 //! ImGui initialization/termination.
 //!
 
-GfxResult gfxImGuiInitialize(GfxContext gfx, ImGuiConfigFlags flags = 0);
+GfxResult gfxImGuiInitialize(GfxContext gfx, char const **font_filenames = nullptr, uint32_t font_count = 0, ImFontConfig const *font_configs = nullptr, ImGuiConfigFlags flags = 0);
 GfxResult gfxImGuiTerminate();
 GfxResult gfxImGuiRender(GfxTexture output_texture = {});
 GfxResult gfxImGuiComposite(GfxTexture color_texture, GfxTexture imgui_texture);


### PR DESCRIPTION
This updates the backend to:
 - Support `ImGuiBackendFlags_RendererHasTextures`: Font textures are now generated on first use and glyphs no longer have to be pre-backed
 - Add linear sampler support for better glyph rendering
 - Support DrawCallbacks: DrawCallbacks are used to either reset render state or to change the sampler between linear/nearest
 - Support `ImGuiBackendFlags_RendererHasVtxOffset`: Allows rendering larger meshes beyond what int16 index buffers could normally support