### PR TITLE
Increase kGfxConstant_NumBindlessSlots

### DIFF
--- a/gfx_core.h
+++ b/gfx_core.h
@@ -51,7 +51,7 @@ enum GfxConstant
     kGfxConstant_MaxRenderTarget  = 8,
     kGfxConstant_MaxAnisotropy    = 8,
     kGfxConstant_MaxNameLength    = 64,
-    kGfxConstant_NumBindlessSlots = 1024
+    kGfxConstant_NumBindlessSlots = 2048
 };
 
 //!


### PR DESCRIPTION
Increase `kGfxConstant_NumBindlessSlots`  in `gfx_core.h`  from 1024 to 2048

Some scenes can exceed 1024 unique textures, causing out-of-bounds bindless descriptor access which leads to corrupted / invalid texture data and possibly GPU hangs.

Doubling the limit to 2048 is a short-term fix before a proper dynamic bindless texture count solution is implemented.