### PR TITLE
Allow multiple geometries in BLAS builds

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2852,12 +2852,8 @@ public:
         blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
         blas_inputs.NumDescs = static_cast<UINT>(descs.size());
         blas_inputs.pGeometryDescs = descs.data();
-        // if (update)
-        //{
-        //     blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
-        // }
 
-        // HACK: use first batch element to store BLAS BVH buffer
+        // Use first batch element to store BLAS BVH buffer
         RaytracingPrimitive &gfx_raytracing_primitive = raytracing_primitives_[batch[0].primitive];
         GfxBuffer &bvh_buffer = gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles
                                   ? gfx_raytracing_primitive.triangles_.bvh_buffer_

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2716,6 +2716,197 @@ public:
         return buildRaytracingPrimitive(raytracing_primitive, gfx_raytracing_primitive, false);
     }
 
+    GfxResult buildRaytracingPrimitiveBatch(GfxRaytracingPrimitiveBatchElement const *batch, size_t batch_size)
+    {
+        if(dxr_device_ == nullptr)
+            return kGfxResult_InvalidOperation; // avoid spamming console output
+        if (batch == nullptr || batch_size == 0)
+            return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot build a raytracing primitives using an empty batch");
+        std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> descs;
+        descs.reserve(batch_size);
+        bool transition = false;
+        for (size_t i = 0; i < batch_size; ++i)
+        {
+            GfxRaytracingPrimitiveBatchElement const &element = batch[i];
+            // Check element for validity
+            if (!raytracing_primitive_handles_.has_handle(element.primitive.handle))
+                return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot set geometry on an invalid raytracing primitive object");
+            RaytracingPrimitive &gfx_raytracing_primitive = raytracing_primitives_[element.primitive];
+            if (gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles)
+            {
+                if (!buffer_handles_.has_handle(element.index_buffer.handle))
+                    return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot build a raytracing primitive using an invalid index buffer object");
+                if (!buffer_handles_.has_handle(element.vertex_buffer.handle))
+                    return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot build a raytracing primitive using an invalid vertex buffer object");
+                uint32_t const index_stride = (element.index_buffer.stride == 2 ? 2 : 4);
+                if (element.index_buffer.size / index_stride > 0xFFFFFFFFull)
+                    return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot build a raytracing primitive with a buffer object containing more than 4 billion indices");
+                uint32_t const vertex_stride = (element.vertex_stride != 0 ? element.vertex_stride : element.vertex_buffer.stride);
+                if (vertex_stride == 0)
+                    return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot build a raytracing primitive with a vertex buffer object of stride `0'");
+                if (element.vertex_buffer.size / vertex_stride > 0xFFFFFFFFull)
+                    return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot build a raytracing primitive with a buffer object containing more than 4 billion vertices");
+                // Clear old and create new vertex and index buffers on internal side of gfx
+                destroyBuffer(gfx_raytracing_primitive.triangles_.index_buffer_);
+                destroyBuffer(gfx_raytracing_primitive.triangles_.vertex_buffer_);
+                gfx_raytracing_primitive.triangles_.build_flags_ = (uint32_t)element.flags;
+                gfx_raytracing_primitive.triangles_.index_buffer_ = createBufferRange(element.index_buffer, 0, element.index_buffer.size);
+                gfx_raytracing_primitive.triangles_.index_stride_ = index_stride;
+                gfx_raytracing_primitive.triangles_.vertex_buffer_ = createBufferRange(element.vertex_buffer, 0, element.vertex_buffer.size);
+                gfx_raytracing_primitive.triangles_.vertex_stride_ = vertex_stride;
+                if (gfx_raytracing_primitive.triangles_.index_stride_ != 0 && !buffer_handles_.has_handle(gfx_raytracing_primitive.triangles_.index_buffer_.handle))
+                    return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid index buffer object");
+                if (!buffer_handles_.has_handle(gfx_raytracing_primitive.triangles_.vertex_buffer_.handle))
+                    return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid vertex buffer object");
+                GFX_ASSERT(gfx_raytracing_primitive.triangles_.index_stride_ == 0
+                    || gfx_raytracing_primitive.triangles_.index_buffer_.size / gfx_raytracing_primitive.triangles_.index_stride_ <= 0xFFFFFFFFull);
+                GFX_ASSERT(gfx_raytracing_primitive.triangles_.vertex_stride_ > 0
+                           && gfx_raytracing_primitive.triangles_.vertex_buffer_.size / gfx_raytracing_primitive.triangles_.vertex_stride_ <= 0xFFFFFFFFull);
+                Buffer *gfx_index_buffer = (gfx_raytracing_primitive.triangles_.index_stride_ != 0
+                                                ? &buffers_[gfx_raytracing_primitive.triangles_.index_buffer_]
+                                                : nullptr);
+                if (gfx_index_buffer != nullptr)
+                    SetObjectName(*gfx_index_buffer, gfx_raytracing_primitive.triangles_.index_buffer_.name);
+                Buffer &gfx_vertex_buffer = buffers_[gfx_raytracing_primitive.triangles_.vertex_buffer_];
+                SetObjectName(gfx_vertex_buffer, gfx_raytracing_primitive.triangles_.vertex_buffer_.name);
+                GFX_TRY(updateRaytracingPrimitive(element.primitive, gfx_raytracing_primitive));
+                if ((gfx_raytracing_primitive.triangles_.index_stride_ != 0 && gfx_raytracing_primitive.triangles_.index_buffer_.size == 0)
+                    || gfx_raytracing_primitive.triangles_.vertex_buffer_.size == 0)
+                {
+                    destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_buffer_);
+                    gfx_raytracing_primitive.triangles_.bvh_buffer_ = {};
+                    return kGfxResult_NoError;
+                }
+
+                D3D12_RAYTRACING_GEOMETRY_DESC geometry_desc = {};
+                geometry_desc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+                if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Opaque) != 0)
+                    geometry_desc.Flags |= D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE;
+                GFX_ASSERT(gfx_raytracing_primitive.triangles_.index_stride_ == 0 || gfx_index_buffer != nullptr); // should never happen
+                if (gfx_index_buffer != nullptr)
+                {
+                    geometry_desc.Triangles.IndexFormat = (gfx_raytracing_primitive.triangles_.index_stride_ == 2 ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT);
+                    geometry_desc.Triangles.IndexCount = (uint32_t)(gfx_raytracing_primitive.triangles_.index_buffer_.size / gfx_raytracing_primitive.triangles_.index_stride_);
+                    geometry_desc.Triangles.IndexBuffer = gfx_index_buffer->resource_->GetGPUVirtualAddress() + gfx_index_buffer->data_offset_;
+                }
+                geometry_desc.Triangles.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
+                geometry_desc.Triangles.VertexCount = (uint32_t)(gfx_raytracing_primitive.triangles_.vertex_buffer_.size / gfx_raytracing_primitive.triangles_.vertex_stride_);
+                geometry_desc.Triangles.VertexBuffer.StartAddress = gfx_vertex_buffer.resource_->GetGPUVirtualAddress() + gfx_vertex_buffer.data_offset_;
+                geometry_desc.Triangles.VertexBuffer.StrideInBytes = gfx_raytracing_primitive.triangles_.vertex_stride_;
+                descs.push_back(geometry_desc);
+                transition |= transitionResource(buffers_[gfx_raytracing_primitive.triangles_.vertex_buffer_], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, kTransitionType_Implicit);
+                if (gfx_raytracing_primitive.triangles_.index_stride_ != 0)
+                    transition |= transitionResource(buffers_[gfx_raytracing_primitive.triangles_.index_buffer_], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, kTransitionType_Implicit);
+            }
+            else if (gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Procedural)
+            {
+                // TODO: support other primitive types
+                GFX_ASSERT(false);
+
+                // if (!raytracing_primitive_handles_.has_handle(element.primitive.handle))
+                //{
+                //     return GFX_SET_ERROR(kGfxResult_InvalidParameter,
+                //         "Cannot set geometry on an invalid raytracing primitive object");
+                // }
+                // if (!buffer_handles_.has_handle(aabb_buffer.handle))
+                //{
+                //     return GFX_SET_ERROR(kGfxResult_InvalidParameter,
+                //         "Cannot build a raytracing primitive using an invalid AABB buffer object");
+                // }
+                // aabb_stride = (aabb_stride != 0 ? aabb_stride : aabb_buffer.stride);
+                // if (aabb_stride == 0)
+                //{
+                //     return GFX_SET_ERROR(kGfxResult_InvalidOperation,
+                //         "Cannot build a raytracing primitive with an AABB buffer object of stride `0'");
+                // }
+                // if (aabb_buffer.size / aabb_stride > 0xFFFFFFFFull)
+                //{
+                //     return GFX_SET_ERROR(kGfxResult_InvalidOperation,
+                //         "Cannot build a raytracing primitive with a buffer object containing more than 4
+                //         billion AABBs");
+                // }
+                // RaytracingPrimitive &gfx_raytracing_primitive =
+                // raytracing_primitives_[raytracing_primitive]; if (gfx_raytracing_primitive.type_ !=
+                // RaytracingPrimitive::kType_Procedural)
+                //{
+                //     return GFX_SET_ERROR(kGfxResult_InvalidOperation,
+                //         "Cannot build a non-procedural raytracing primitive object");
+                // }
+                // destroyBuffer(gfx_raytracing_primitive.procedural_.procedural_buffer_);
+                // gfx_raytracing_primitive.procedural_.build_flags_ = (uint32_t)build_flags;
+                // gfx_raytracing_primitive.procedural_.procedural_buffer_ =
+                //     createBufferRange(aabb_buffer, 0, aabb_buffer.size);
+                // gfx_raytracing_primitive.procedural_.procedural_stride_ = aabb_stride;
+                // gfx_raytracing_primitive.type_ = RaytracingPrimitive::kType_Procedural;
+
+                // transition |=
+                //     transitionResource(buffers_[gfx_raytracing_primitive.procedural_.procedural_buffer_],
+                //         D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, kTransitionType_Implicit);
+            }
+            else
+                return GFX_SET_ERROR(kGfxResult_InvalidParameter,"Cannot build a raytracing batch using an invalid primitive type");
+        }
+
+        D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS blas_inputs = {};
+        blas_inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+        blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+        blas_inputs.NumDescs = static_cast<UINT>(descs.size());
+        blas_inputs.pGeometryDescs = descs.data();
+        // if (update)
+        //{
+        //     blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+        // }
+
+        // HACK: use first batch element to store BLAS BVH buffer
+        RaytracingPrimitive &gfx_raytracing_primitive = raytracing_primitives_[batch[0].primitive];
+        GfxBuffer &bvh_buffer = gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles
+                                  ? gfx_raytracing_primitive.triangles_.bvh_buffer_
+                                  : gfx_raytracing_primitive.procedural_.bvh_buffer_;
+        GfxAccelerationStructure &acc_struct = gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles
+                ? gfx_raytracing_primitive.triangles_.acceleration_structure_
+                : gfx_raytracing_primitive.procedural_.acceleration_structure_;
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO blas_info = {};
+        dxr_device_->GetRaytracingAccelerationStructurePrebuildInfo(&blas_inputs, &blas_info);
+        uint64_t const scratch_data_size = GFX_MAX(blas_info.ScratchDataSizeInBytes, blas_info.UpdateScratchDataSizeInBytes);
+        GFX_TRY(allocateRaytracingScratch(scratch_data_size)); // ensure scratch is large enough
+        uint64_t const bvh_data_size = GFX_ALIGN(blas_info.ResultDataMaxSizeInBytes, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BYTE_ALIGNMENT);
+        if (bvh_data_size > bvh_buffer.size)
+        {
+            if (!bvh_buffer)
+            {
+                GFX_ASSERT(acceleration_structure_handles_.has_handle(acc_struct.handle)); // checked in `updateRaytracingPrimitive()'
+                AccelerationStructure &gfx_acceleration_structure = acceleration_structures_[acc_struct];
+                gfx_acceleration_structure.needs_rebuild_ = true; // raytracing primitive has been built, rebuild the acceleration structure
+            }
+            destroyBuffer(bvh_buffer);
+            blas_inputs.Flags &= ~D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+            bvh_buffer = createBuffer(bvh_data_size, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+            if (!bvh_buffer)
+                return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create raytracing primitive buffer");
+        }
+        uint64_t &data_size = gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles
+                                ? gfx_raytracing_primitive.triangles_.bvh_data_size_
+                                : gfx_raytracing_primitive.procedural_.bvh_data_size_;
+        data_size = (uint64_t)blas_info.ResultDataMaxSizeInBytes;
+        GFX_ASSERT(buffer_handles_.has_handle(bvh_buffer.handle));
+        GFX_ASSERT(buffer_handles_.has_handle(raytracing_scratch_buffer_.handle));
+        Buffer &gfx_buffer = buffers_[bvh_buffer];
+        Buffer &gfx_scratch_buffer = buffers_[raytracing_scratch_buffer_];
+        SetObjectName(gfx_buffer, "BLAS batch build buffer");
+        transition |= transitionResource(gfx_scratch_buffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+        if (transition)
+            submitPipelineBarriers(); // ensure scratch is not in use
+        D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC build_desc = {};
+        build_desc.DestAccelerationStructureData = gfx_buffer.resource_->GetGPUVirtualAddress() + gfx_buffer.data_offset_;
+        build_desc.Inputs = blas_inputs;
+        if ((blas_inputs.Flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE) != 0)
+            build_desc.SourceAccelerationStructureData = gfx_buffer.resource_->GetGPUVirtualAddress() + gfx_buffer.data_offset_;
+        build_desc.ScratchAccelerationStructureData = gfx_scratch_buffer.resource_->GetGPUVirtualAddress() + gfx_scratch_buffer.data_offset_;
+        GFX_ASSERT(dxr_command_list_ != nullptr); // should never happen
+        dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, 0, nullptr);
+        return kGfxResult_NoError;
+    }
+
     GfxResult setRaytracingPrimitiveTransform(GfxRaytracingPrimitive const &raytracing_primitive, float const *row_major_4x4_transform)
     {
         if(dxr_device_ == nullptr)
@@ -7639,7 +7830,7 @@ private:
         dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, 0, nullptr);
         return kGfxResult_NoError;
     }
-
+    
     GfxResult updateRaytracingPrimitive(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive)
     {
         GfxAccelerationStructure const &acceleration_structure = getRaytracingPrimitiveAccelerationStructure(gfx_raytracing_primitive);
@@ -10456,6 +10647,13 @@ GfxResult gfxRaytracingPrimitiveBuildProcedural(GfxContext context, GfxRaytracin
     GfxInternal *gfx = GfxInternal::GetGfx(context);
     if(!gfx) return kGfxResult_InvalidParameter;
     return gfx->buildRaytracingPrimitiveProcedural(raytracing_primitive, aabb_buffer, aabb_stride, build_flags);
+}
+
+GfxResult gfxRaytracingPrimitiveBuildBatch(GfxContext context, GfxRaytracingPrimitiveBatchElement const *batch, size_t batch_size)
+{
+    GfxInternal *gfx = GfxInternal::GetGfx(context);
+    if(!gfx) return kGfxResult_InvalidParameter;
+    return gfx->buildRaytracingPrimitiveBatch(batch, batch_size);
 }
 
 GfxResult gfxRaytracingPrimitiveSetTransform(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, float const *row_major_4x4_transform)

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2798,51 +2798,6 @@ public:
                 if (gfx_raytracing_primitive.triangles_.index_stride_ != 0)
                     transition |= transitionResource(buffers_[gfx_raytracing_primitive.triangles_.index_buffer_], D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, kTransitionType_Implicit);
             }
-            else if (gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Procedural)
-            {
-                // TODO: support other primitive types
-                GFX_ASSERT(false);
-
-                // if (!raytracing_primitive_handles_.has_handle(element.primitive.handle))
-                //{
-                //     return GFX_SET_ERROR(kGfxResult_InvalidParameter,
-                //         "Cannot set geometry on an invalid raytracing primitive object");
-                // }
-                // if (!buffer_handles_.has_handle(aabb_buffer.handle))
-                //{
-                //     return GFX_SET_ERROR(kGfxResult_InvalidParameter,
-                //         "Cannot build a raytracing primitive using an invalid AABB buffer object");
-                // }
-                // aabb_stride = (aabb_stride != 0 ? aabb_stride : aabb_buffer.stride);
-                // if (aabb_stride == 0)
-                //{
-                //     return GFX_SET_ERROR(kGfxResult_InvalidOperation,
-                //         "Cannot build a raytracing primitive with an AABB buffer object of stride `0'");
-                // }
-                // if (aabb_buffer.size / aabb_stride > 0xFFFFFFFFull)
-                //{
-                //     return GFX_SET_ERROR(kGfxResult_InvalidOperation,
-                //         "Cannot build a raytracing primitive with a buffer object containing more than 4
-                //         billion AABBs");
-                // }
-                // RaytracingPrimitive &gfx_raytracing_primitive =
-                // raytracing_primitives_[raytracing_primitive]; if (gfx_raytracing_primitive.type_ !=
-                // RaytracingPrimitive::kType_Procedural)
-                //{
-                //     return GFX_SET_ERROR(kGfxResult_InvalidOperation,
-                //         "Cannot build a non-procedural raytracing primitive object");
-                // }
-                // destroyBuffer(gfx_raytracing_primitive.procedural_.procedural_buffer_);
-                // gfx_raytracing_primitive.procedural_.build_flags_ = (uint32_t)build_flags;
-                // gfx_raytracing_primitive.procedural_.procedural_buffer_ =
-                //     createBufferRange(aabb_buffer, 0, aabb_buffer.size);
-                // gfx_raytracing_primitive.procedural_.procedural_stride_ = aabb_stride;
-                // gfx_raytracing_primitive.type_ = RaytracingPrimitive::kType_Procedural;
-
-                // transition |=
-                //     transitionResource(buffers_[gfx_raytracing_primitive.procedural_.procedural_buffer_],
-                //         D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, kTransitionType_Implicit);
-            }
             else
                 return GFX_SET_ERROR(kGfxResult_InvalidParameter,"Cannot build a raytracing batch using an invalid primitive type");
         }

--- a/gfx.h
+++ b/gfx.h
@@ -229,6 +229,17 @@ GfxResult gfxRaytracingPrimitiveBuild(GfxContext context, GfxRaytracingPrimitive
 GfxResult gfxRaytracingPrimitiveBuild(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer index_buffer, GfxBuffer vertex_buffer, uint32_t vertex_stride = 0, GfxBuildRaytracingPrimitiveFlags build_flags = 0);
 GfxResult gfxRaytracingPrimitiveBuildProcedural(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer aabb_buffer, uint32_t aabb_stride = 0, GfxBuildRaytracingPrimitiveFlags build_flags = 0);
 
+struct GfxRaytracingPrimitiveBatchElement
+{
+    GfxRaytracingPrimitive primitive;
+    GfxBuffer index_buffer;
+    GfxBuffer vertex_buffer;
+    uint32_t vertex_stride = 0;
+    GfxBuildRaytracingPrimitiveFlags flags = 0;
+};
+
+GfxResult gfxRaytracingPrimitiveBuildBatch(GfxContext context, GfxRaytracingPrimitiveBatchElement const *batch, size_t batch_size);
+
 GfxResult gfxRaytracingPrimitiveSetTransform(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, float const *row_major_4x4_transform);
 GfxResult gfxRaytracingPrimitiveSetInstanceID(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, uint32_t instance_id);   // retrieved through `ray_query.CommittedInstanceID()`
 GfxResult gfxRaytracingPrimitiveSetInstanceMask(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, uint8_t instance_mask);

--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -177,6 +177,8 @@ class GfxSceneInternal
     GfxArray<uint64_t> instance_refs_;
     GfxArray<GfxMetadata> instance_metadata_;
     GfxHandles instance_handles_;
+    
+    std::vector<std::vector<uint64_t>> instances_by_transform_;
 
     static GfxArray<GfxScene> scenes_;
     static GfxHandles scene_handles_;
@@ -521,6 +523,11 @@ public:
     }
 
     static inline GfxSceneInternal *GetGfxScene(GfxScene scene) { return reinterpret_cast<GfxSceneInternal *>(scene.handle); }
+
+    inline std::vector<std::vector<uint64_t>> getInstancesBySameTransform() const
+    {
+        return instances_by_transform_;
+    }
 
 private:
     static inline uint32_t GetObjectIndex(uint64_t object_handle)
@@ -1958,10 +1965,14 @@ private:
                 if(it != meshes.end())
                 {
                     instances.reserve((*it).second.size());
+                    std::vector<uint64_t> same_transform;
+                    same_transform.reserve((*it).second.size());
+                    
                     for(size_t i = 0; i < (*it).second.size(); ++i)
                     {
                         GfxRef<GfxInstance> instance_ref = gfxSceneCreateInstance(scene);
                         instances.push_back(instance_ref);
+                        same_transform.push_back(instance_ref);
                         GfxConstRef<GfxMesh> mesh = it->second[i].first;
                         instance_ref->mesh      = mesh;
                         instance_ref->material  = it->second[i].second;
@@ -1983,6 +1994,8 @@ private:
                         else
                             instance_metadata.asset_file = asset_file;
                     }
+                    
+                    instances_by_transform_.push_back(same_transform);
                 }
             }
             GfxRef<GfxCamera> camera;
@@ -3621,4 +3634,11 @@ bool gfxSceneSetInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMe
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return false;    // invalid parameter
     return gfx_scene->setObjectMetadata<GfxInstance>(instance_handle, metadata);
+}
+
+std::vector<std::vector<uint64_t>> gfxSceneGetInstancesBySameTransform(GfxScene scene)
+{
+    GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if(!gfx_scene) return {};    // invalid parameter
+    return gfx_scene->getInstancesBySameTransform();
 }

--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -78,8 +78,8 @@ class GfxSceneInternal
         GfxRef<GfxSkin> skin_;
         GfxRef<GfxLight> light_;
         GfxRef<GfxCamera> camera_;
+        GfxRef<GfxRenderInstance> instance_;
         std::vector<uint64_t> children_;
-        std::vector<GfxRef<GfxInstance>> instances_;
         std::vector<float> default_weights_;
     };
 
@@ -173,12 +173,15 @@ class GfxSceneInternal
     GfxArray<GfxMetadata> mesh_metadata_;
     GfxHandles mesh_handles_;
 
-    GfxArray<GfxInstance> instances_;
-    GfxArray<uint64_t> instance_refs_;
-    GfxArray<GfxMetadata> instance_metadata_;
-    GfxHandles instance_handles_;
+    GfxArray<GfxMeshInstance> mesh_instances_;
+    GfxArray<uint64_t> mesh_instance_refs_;
+    GfxArray<GfxMetadata> mesh_instance_metadata_;
+    GfxHandles mesh_instance_handles_;
     
-    std::vector<std::vector<uint64_t>> instances_by_transform_;
+    GfxArray<GfxRenderInstance> render_instances_;
+    GfxArray<uint64_t> render_instance_refs_;
+    GfxArray<GfxMetadata> render_instance_metadata_;
+    GfxHandles render_instance_handles_;
 
     static GfxArray<GfxScene> scenes_;
     static GfxHandles scene_handles_;
@@ -223,14 +226,20 @@ class GfxSceneInternal
     template<> inline GfxArray<GfxMetadata> &object_metadata_<GfxMesh>() { return mesh_metadata_; }
     template<> inline GfxHandles &object_handles_<GfxMesh>() { return mesh_handles_; }
 
-    template<> inline GfxArray<GfxInstance> &objects_<GfxInstance>() { return instances_; }
-    template<> inline GfxArray<uint64_t> &object_refs_<GfxInstance>() { return instance_refs_; }
-    template<> inline GfxArray<GfxMetadata> &object_metadata_<GfxInstance>() { return instance_metadata_; }
-    template<> inline GfxHandles &object_handles_<GfxInstance>() { return instance_handles_; }
+    template<> inline GfxArray<GfxMeshInstance> &objects_<GfxMeshInstance>() { return mesh_instances_; }
+    template<> inline GfxArray<uint64_t> &object_refs_<GfxMeshInstance>() { return mesh_instance_refs_; }
+    template<> inline GfxArray<GfxMetadata> &object_metadata_<GfxMeshInstance>() { return mesh_instance_metadata_; }
+    template<> inline GfxHandles &object_handles_<GfxMeshInstance>() { return mesh_instance_handles_; }
+
+    template<> inline GfxArray<GfxRenderInstance>& objects_<GfxRenderInstance>() { return render_instances_; }
+    template<> inline GfxArray<uint64_t>& object_refs_<GfxRenderInstance>() { return render_instance_refs_; }
+    template<> inline GfxArray<GfxMetadata>& object_metadata_<GfxRenderInstance>() { return render_instance_metadata_; }
+    template<> inline GfxHandles& object_handles_<GfxRenderInstance>() { return render_instance_handles_; }
 
 public:
     GfxSceneInternal(GfxScene &scene) : gltf_node_handles_("gltf_node"), animation_handles_("animation"), skin_handles_("skin"), camera_handles_("camera")
-                                      , image_handles_("image"), material_handles_("material"), mesh_handles_("mesh"), instance_handles_("instance")
+                                      , image_handles_("image"), material_handles_("material"), mesh_handles_("mesh"), mesh_instance_handles_("mesh_instance")
+                                      , render_instance_handles_("render_instance")
                                       { scene.handle = reinterpret_cast<uint64_t>(this); }
     ~GfxSceneInternal() { terminate(); }
 
@@ -290,7 +299,8 @@ public:
         clearObjects<GfxImage>();
         clearObjects<GfxMaterial>();
         clearObjects<GfxMesh>();
-        clearObjects<GfxInstance>();
+        clearObjects<GfxMeshInstance>();
+        clearObjects<GfxRenderInstance>();
         clearNodes();
 
         return kGfxResult_NoError;
@@ -323,9 +333,8 @@ public:
                 glm::dmat4 const transform = parent_transform * node.default_local_transform_;
                 for(size_t i = 0; i < node.children_.size(); ++i)
                     VisitNode(node.children_[i], transform);
-                for(size_t i = 0; i < node.instances_.size(); ++i)
-                    if(node.instances_[i])
-                        node.instances_[i]->transform = glm::mat4(transform);
+                if(node.instance_)
+                    node.instance_->transform = glm::mat4(transform);
                 if(node.camera_)
                     TransformGltfCamera(*node.camera_, transform);
                 if(node.light_)
@@ -338,15 +347,16 @@ public:
                 GltfAnimationChannel const &channel = gltf_animation->channels_[i];
                 if(!gltf_node_handles_.has_handle(channel.node_) || (channel.type_ != kGltfAnimationChannelType_Weights)) continue;
                 GltfNode const &node = gltf_nodes_[GetObjectIndex(channel.node_)];
-                for(size_t j = 0; j < node.instances_.size(); ++j)
+                for(size_t j = 0; j < node.instance_->instances.size(); ++j)
                 {
-                    if(!node.instances_[j]) continue;
+                    GfxRef<GfxMeshInstance>& instance = node.instance_->instances[j];
+                    if(!instance) continue;
                     if(!node.default_weights_.empty())
-                        node.instances_[j]->weights = node.default_weights_;
-                    else if(!node.instances_[j]->mesh->default_weights.empty())
-                        node.instances_[j]->weights = node.instances_[j]->mesh->default_weights;
+                        instance->weights = node.default_weights_;
+                    else if(!instance->mesh->default_weights.empty())
+                        instance->weights = instance->mesh->default_weights;
                     else
-                        std::fill(node.instances_[j]->weights.begin(), node.instances_[j]->weights.end(), 0.0f);
+                        std::fill(instance->weights.begin(), instance->weights.end(), 0.0f);
                 }
             }
         }
@@ -523,11 +533,6 @@ public:
     }
 
     static inline GfxSceneInternal *GetGfxScene(GfxScene scene) { return reinterpret_cast<GfxSceneInternal *>(scene.handle); }
-
-    inline std::vector<std::vector<uint64_t>> getInstancesBySameTransform() const
-    {
-        return instances_by_transform_;
-    }
 
 private:
     static inline uint32_t GetObjectIndex(uint64_t object_handle)
@@ -988,10 +993,10 @@ private:
                         animation_channel.values_[next_index * weights_count + j], interpolate);
                 }
                 GltfNode const &node = gltf_nodes_[GetObjectIndex(animation_channel.node_)];
-                for(size_t j = 0; j < node.instances_.size(); ++j)
+                for(size_t j = 0; j < node.instance_->instances.size(); ++j)
                 {
-                    if(!node.instances_[j]) continue;
-                    node.instances_[j]->weights = weights;
+                    if(!node.instance_->instances[j]) continue;
+                    node.instance_->instances[j]->weights = weights;
                 }
             }
         }
@@ -1012,9 +1017,8 @@ private:
                     animated_node->translate_, animated_node->rotate_, animated_node->scale_);
             for(size_t i = 0; i < node.children_.size(); ++i)
                 VisitNode(node.children_[i], node.world_transform_);
-            for(size_t i = 0; i < node.instances_.size(); ++i)
-                if(node.instances_[i])
-                    node.instances_[i]->transform = glm::mat4(node.world_transform_);
+            if(node.instance_)
+                node.instance_->transform = glm::mat4(node.world_transform_);
             if(node.camera_)
                 TransformGltfCamera(*node.camera_, node.world_transform_);
             if(node.light_)
@@ -1184,11 +1188,11 @@ private:
                 }
                 mesh_ref->bounds_min = bounds_min;
                 mesh_ref->bounds_max = bounds_max;
-                GfxRef<GfxInstance> instance_ref = gfxSceneCreateInstance(scene);
+                GfxRef<GfxMeshInstance> instance_ref = gfxSceneCreateMeshInstance(scene);
                 instance_ref->mesh = mesh_ref;  // .obj does not support instancing, so simply create one instance per mesh
                 if((*it).first < materials.size())
                     instance_ref->material = materials[(*it).first];
-                GfxMetadata &instance_metadata = instance_metadata_[instance_ref];
+                GfxMetadata &instance_metadata = mesh_instance_metadata_[instance_ref];
                 instance_metadata.asset_file = asset_file;  // set up metadata
                 instance_metadata.object_name = obj_shape.name;
                 if(mesh_id > 0)
@@ -1948,7 +1952,7 @@ private:
                 local_transform = glm::scale(local_transform,
                     glm::vec3(gltf_node->scale[0], gltf_node->scale[1], gltf_node->scale[2]));
             }
-            std::vector<GfxRef<GfxInstance>> instances;
+            std::vector<GfxRef<GfxMeshInstance>> mesh_instances;
             glm::mat4 const transform = parent_transform * local_transform;
             GfxRef<GfxSkin> skin;
             if(gltf_node->skin != nullptr)
@@ -1964,38 +1968,32 @@ private:
                 std::map<cgltf_mesh const *, std::vector<instance_pair>>::const_iterator const it = meshes.find(gltf_node->mesh);
                 if(it != meshes.end())
                 {
-                    instances.reserve((*it).second.size());
-                    std::vector<uint64_t> same_transform;
-                    same_transform.reserve((*it).second.size());
+                    mesh_instances.reserve((*it).second.size());
                     
                     for(size_t i = 0; i < (*it).second.size(); ++i)
                     {
-                        GfxRef<GfxInstance> instance_ref = gfxSceneCreateInstance(scene);
-                        instances.push_back(instance_ref);
-                        same_transform.push_back(instance_ref);
+                        GfxRef<GfxMeshInstance> mesh_instance_ref = gfxSceneCreateMeshInstance(scene);
+                        mesh_instances.push_back(mesh_instance_ref);
                         GfxConstRef<GfxMesh> mesh = it->second[i].first;
-                        instance_ref->mesh      = mesh;
-                        instance_ref->material  = it->second[i].second;
-                        instance_ref->skin      = skin;
-                        instance_ref->transform = glm::mat4(transform);
+                        mesh_instance_ref->mesh      = mesh;
+                        mesh_instance_ref->material  = it->second[i].second;
+                        mesh_instance_ref->skin      = skin;
                         if(!mesh->morph_targets.empty())
                         {
                             if(gltf_node->weights != nullptr)
-                                instance_ref->weights = std::vector<float>(gltf_node->weights, gltf_node->weights + gltf_node->weights_count);
+                                mesh_instance_ref->weights = std::vector<float>(gltf_node->weights, gltf_node->weights + gltf_node->weights_count);
                             else if(!mesh->default_weights.empty())
-                                instance_ref->weights = mesh->default_weights;
+                                mesh_instance_ref->weights = mesh->default_weights;
                             else
-                                instance_ref->weights = std::vector<float>(mesh->morph_targets.size() / mesh->vertices.size(), 0.0f);
+                                mesh_instance_ref->weights = std::vector<float>(mesh->morph_targets.size() / mesh->vertices.size(), 0.0f);
                         }
-                        GfxMetadata &instance_metadata = instance_metadata_[instance_ref];
+                        GfxMetadata &mesh_instance_metadata = mesh_instance_metadata_[mesh_instance_ref];
                         GfxMetadata const *mesh_metadata = mesh_metadata_.at(it->second[i].first);
                         if(mesh_metadata != nullptr)
-                            instance_metadata = *mesh_metadata; // set up metadata
+                            mesh_instance_metadata = *mesh_metadata; // set up metadata
                         else
-                            instance_metadata.asset_file = asset_file;
+                            mesh_instance_metadata.asset_file = asset_file;
                     }
-                    
-                    instances_by_transform_.push_back(same_transform);
                 }
             }
             GfxRef<GfxCamera> camera;
@@ -2074,7 +2072,10 @@ private:
             node.world_transform_ = transform;
             node.parent_ = parent_handle;
             std::swap(node.children_, children);
-            std::swap(node.instances_, instances);
+            GfxRef<GfxRenderInstance> render_instance = gfxSceneCreateRenderInstance(scene);
+            render_instance->transform = transform;
+            std::swap(render_instance->instances, mesh_instances);
+            node.instance_ = render_instance;
             node.skin_ = skin;
             node.camera_ = camera;
             node.light_ = light;
@@ -3570,75 +3571,134 @@ bool gfxSceneSetMeshMetadata(GfxScene scene, uint64_t mesh_handle, GfxMetadata c
     return gfx_scene->setObjectMetadata<GfxMesh>(mesh_handle, metadata);
 }
 
-GfxRef<GfxInstance> gfxSceneCreateInstance(GfxScene scene)
+GfxRef<GfxMeshInstance> gfxSceneCreateMeshInstance(GfxScene scene)
 {
-    GfxRef<GfxInstance> const instance_ref = {};
+    GfxRef<GfxMeshInstance> const instance_ref = {};
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return instance_ref; // invalid parameter
-    return gfx_scene->createObject<GfxInstance>(scene);
+    return gfx_scene->createObject<GfxMeshInstance>(scene);
 }
 
-GfxResult gfxSceneDestroyInstance(GfxScene scene, uint64_t instance_handle)
+GfxResult gfxSceneDestroyMeshInstance(GfxScene scene, uint64_t instance_handle)
 {
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return kGfxResult_InvalidParameter;
-    return gfx_scene->destroyObject<GfxInstance>(instance_handle);
+    return gfx_scene->destroyObject<GfxMeshInstance>(instance_handle);
 }
 
-GfxResult gfxSceneDestroyAllInstances(GfxScene scene)
+GfxResult gfxSceneDestroyAllMeshInstances(GfxScene scene)
 {
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return kGfxResult_InvalidParameter;
-    return gfx_scene->clearObjects<GfxInstance>();
+    return gfx_scene->clearObjects<GfxMeshInstance>();
 }
 
-uint32_t gfxSceneGetInstanceCount(GfxScene scene)
+uint32_t gfxSceneGetMeshInstanceCount(GfxScene scene)
 {
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return 0;    // invalid parameter
-    return gfx_scene->getObjectCount<GfxInstance>();
+    return gfx_scene->getObjectCount<GfxMeshInstance>();
 }
 
-GfxInstance const *gfxSceneGetInstances(GfxScene scene)
+GfxMeshInstance const *gfxSceneGetMeshInstances(GfxScene scene)
 {
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return nullptr;  // invalid parameter
-    return gfx_scene->getObjects<GfxInstance>();
+    return gfx_scene->getObjects<GfxMeshInstance>();
 }
 
-GfxInstance *gfxSceneGetInstance(GfxScene scene, uint64_t instance_handle)
+GfxMeshInstance *gfxSceneGetMeshInstance(GfxScene scene, uint64_t instance_handle)
 {
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return nullptr;  // invalid parameter
-    return gfx_scene->getObject<GfxInstance>(instance_handle);
+    return gfx_scene->getObject<GfxMeshInstance>(instance_handle);
 }
 
-GfxRef<GfxInstance> gfxSceneGetInstanceHandle(GfxScene scene, uint32_t instance_index)
+GfxRef<GfxMeshInstance> gfxSceneGetMeshInstanceHandle(GfxScene scene, uint32_t instance_index)
 {
-    GfxRef<GfxInstance> const instance_ref = {};
+    GfxRef<GfxMeshInstance> const instance_ref = {};
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return instance_ref; // invalid parameter
-    return gfx_scene->getObjectHandle<GfxInstance>(scene, instance_index);
+    return gfx_scene->getObjectHandle<GfxMeshInstance>(scene, instance_index);
 }
 
-GfxMetadata const &gfxSceneGetInstanceMetadata(GfxScene scene, uint64_t instance_handle)
+GfxMetadata const &gfxSceneGetMeshInstanceMetadata(GfxScene scene, uint64_t instance_handle)
 {
     static GfxMetadata const metadata = {};
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return metadata; // invalid parameter
-    return gfx_scene->getObjectMetadata<GfxInstance>(instance_handle);
+    return gfx_scene->getObjectMetadata<GfxMeshInstance>(instance_handle);
 }
 
-bool gfxSceneSetInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMetadata const &metadata)
+bool gfxSceneSetMeshInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMetadata const &metadata)
 {
     GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
     if(!gfx_scene) return false;    // invalid parameter
-    return gfx_scene->setObjectMetadata<GfxInstance>(instance_handle, metadata);
+    return gfx_scene->setObjectMetadata<GfxMeshInstance>(instance_handle, metadata);
 }
 
-std::vector<std::vector<uint64_t>> gfxSceneGetInstancesBySameTransform(GfxScene scene)
+GfxRef<GfxRenderInstance> gfxSceneCreateRenderInstance(GfxScene scene)
 {
-    GfxSceneInternal *gfx_scene = GfxSceneInternal::GetGfxScene(scene);
-    if(!gfx_scene) return {};    // invalid parameter
-    return gfx_scene->getInstancesBySameTransform();
+    GfxRef<GfxRenderInstance> const instance_ref = {};
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return instance_ref; // invalid parameter
+    return gfx_scene->createObject<GfxRenderInstance>(scene);
+}
+
+GfxResult gfxSceneDestroyRenderInstance(GfxScene scene, uint64_t instance_handle)
+{
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return kGfxResult_InvalidParameter;
+    return gfx_scene->destroyObject<GfxRenderInstance>(instance_handle);
+}
+
+GfxResult gfxSceneDestroyAllRenderInstances(GfxScene scene)
+{
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return kGfxResult_InvalidParameter;
+    return gfx_scene->clearObjects<GfxRenderInstance>();
+}
+
+uint32_t gfxSceneGetRenderInstanceCount(GfxScene scene)
+{
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return 0;    // invalid parameter
+    return gfx_scene->getObjectCount<GfxRenderInstance>();
+}
+
+GfxRenderInstance const* gfxSceneGetRenderInstances(GfxScene scene)
+{
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return nullptr;  // invalid parameter
+    return gfx_scene->getObjects<GfxRenderInstance>();
+}
+
+GfxRenderInstance* gfxSceneGetRenderInstance(GfxScene scene, uint64_t instance_handle)
+{
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return nullptr;  // invalid parameter
+    return gfx_scene->getObject<GfxRenderInstance>(instance_handle);
+}
+
+GfxRef<GfxRenderInstance> gfxSceneGetRenderInstanceHandle(GfxScene scene, uint32_t instance_index)
+{
+    GfxRef<GfxRenderInstance> const instance_ref = {};
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return instance_ref; // invalid parameter
+    return gfx_scene->getObjectHandle<GfxRenderInstance>(scene, instance_index);
+}
+
+GfxMetadata const& gfxSceneGetRenderInstanceMetadata(GfxScene scene, uint64_t instance_handle)
+{
+    static GfxMetadata const metadata = {};
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return metadata; // invalid parameter
+    return gfx_scene->getObjectMetadata<GfxRenderInstance>(instance_handle);
+}
+
+bool gfxSceneSetRenderInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMetadata const& metadata)
+{
+    GfxSceneInternal* gfx_scene = GfxSceneInternal::GetGfxScene(scene);
+    if (!gfx_scene) return false;    // invalid parameter
+    return gfx_scene->setObjectMetadata<GfxRenderInstance>(instance_handle, metadata);
 }

--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -1110,6 +1110,8 @@ private:
             }
             materials[i] = material_ref;    // append the new material
         }
+        std::vector<GfxRef<GfxMeshInstance>> instances;
+        instances.reserve(obj_reader.GetShapes().size());
         for(size_t i = 0; i < obj_reader.GetShapes().size(); ++i)
         {
             uint32_t first_index = 0;
@@ -1200,8 +1202,11 @@ private:
                     instance_metadata.object_name += ".";
                     instance_metadata.object_name += std::to_string(mesh_id);
                 }
+                instances.push_back(instance_ref);
             }
         }
+        GfxRef<GfxRenderInstance> render_instance = gfxSceneCreateRenderInstance(scene);
+        std::swap(render_instance->instances, instances);
         return kGfxResult_NoError;
     }
 

--- a/gfx_scene.h
+++ b/gfx_scene.h
@@ -411,30 +411,48 @@ GfxMetadata const &gfxSceneGetMeshMetadata(GfxScene scene, uint64_t mesh_handle)
 bool gfxSceneSetMeshMetadata(GfxScene scene, uint64_t mesh_handle, GfxMetadata const &metadata);
 
 //!
-//! Instance object.
+//! Mesh instance object.
 //!
 
-struct GfxInstance
+struct GfxMeshInstance
 {
     GfxConstRef<GfxMesh>     mesh;
     GfxConstRef<GfxMaterial> material;
     GfxConstRef<GfxSkin>     skin;
     std::vector<float>       weights;
-
-    glm::mat4 transform = glm::mat4(1.0f);
 };
 
-GfxRef<GfxInstance> gfxSceneCreateInstance(GfxScene scene);
-GfxResult gfxSceneDestroyInstance(GfxScene scene, uint64_t instance_handle);
-GfxResult gfxSceneDestroyAllInstances(GfxScene scene);
+GfxRef<GfxMeshInstance> gfxSceneCreateMeshInstance(GfxScene scene);
+GfxResult gfxSceneDestroyMeshInstance(GfxScene scene, uint64_t instance_handle);
+GfxResult gfxSceneDestroyAllMeshInstances(GfxScene scene);
 
-uint32_t gfxSceneGetInstanceCount(GfxScene scene);
-GfxInstance const *gfxSceneGetInstances(GfxScene scene);
-GfxInstance *gfxSceneGetInstance(GfxScene scene, uint64_t instance_handle);
-GfxRef<GfxInstance> gfxSceneGetInstanceHandle(GfxScene scene, uint32_t instance_index);
-GfxMetadata const &gfxSceneGetInstanceMetadata(GfxScene scene, uint64_t instance_handle);
-bool gfxSceneSetInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMetadata const &metadata);
-std::vector<std::vector<uint64_t>> gfxSceneGetInstancesBySameTransform(GfxScene scene);
+uint32_t gfxSceneGetMeshInstanceCount(GfxScene scene);
+GfxMeshInstance const *gfxSceneGetMeshInstances(GfxScene scene);
+GfxMeshInstance *gfxSceneGetMeshInstance(GfxScene scene, uint64_t instance_handle);
+GfxRef<GfxMeshInstance> gfxSceneGetMeshInstanceHandle(GfxScene scene, uint32_t instance_index);
+GfxMetadata const &gfxSceneGetMeshInstanceMetadata(GfxScene scene, uint64_t instance_handle);
+bool gfxSceneSetMeshInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMetadata const &metadata);
+
+//!
+//! Render instance object.
+//! 
+
+struct GfxRenderInstance
+{
+    std::vector<GfxRef<GfxMeshInstance>> instances;
+    glm::mat4                            transform = glm::mat4(1.0f);
+};
+
+GfxRef<GfxRenderInstance> gfxSceneCreateRenderInstance(GfxScene scene);
+GfxResult gfxSceneDestroyRenderInstance(GfxScene scene, uint64_t instance_handle);
+GfxResult gfxSceneDestroyAllRenderInstances(GfxScene scene);
+
+uint32_t gfxSceneGetRenderInstanceCount(GfxScene scene);
+GfxRenderInstance const* gfxSceneGetRenderInstances(GfxScene scene);
+GfxRenderInstance* gfxSceneGetRenderInstance(GfxScene scene, uint64_t instance_handle);
+GfxRef<GfxRenderInstance> gfxSceneGetRenderInstanceHandle(GfxScene scene, uint32_t instance_index);
+GfxMetadata const& gfxSceneGetRenderInstanceMetadata(GfxScene scene, uint64_t instance_handle);
+bool gfxSceneSetRenderInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMetadata const& metadata);
 
 //!
 //! Template specializations.
@@ -489,12 +507,19 @@ template<> inline GfxRef<GfxMesh> gfxSceneGetObjectHandle<GfxMesh>(GfxScene scen
 template<> inline GfxMetadata const &gfxSceneGetObjectMetadata<GfxMesh>(GfxScene scene, uint64_t object_handle) { return gfxSceneGetMeshMetadata(scene, object_handle); }
 template<> inline bool gfxSceneSetObjectMetadata<GfxMesh>(GfxScene scene, uint64_t object_handle, GfxMetadata const &metadata) { return gfxSceneSetMeshMetadata(scene, object_handle, metadata); }
 
-template<> inline uint32_t gfxSceneGetObjectCount<GfxInstance>(GfxScene scene) { return gfxSceneGetInstanceCount(scene); }
-template<> inline GfxInstance const *gfxSceneGetObjects<GfxInstance>(GfxScene scene) { return gfxSceneGetInstances(scene); }
-template<> inline GfxInstance *gfxSceneGetObject<GfxInstance>(GfxScene scene, uint64_t object_handle) { return gfxSceneGetInstance(scene, object_handle); }
-template<> inline GfxRef<GfxInstance> gfxSceneGetObjectHandle<GfxInstance>(GfxScene scene, uint32_t object_index) { return gfxSceneGetInstanceHandle(scene, object_index); }
-template<> inline GfxMetadata const &gfxSceneGetObjectMetadata<GfxInstance>(GfxScene scene, uint64_t object_handle) { return gfxSceneGetInstanceMetadata(scene, object_handle); }
-template<> inline bool gfxSceneSetObjectMetadata<GfxInstance>(GfxScene scene, uint64_t object_handle, GfxMetadata const &metadata) { return gfxSceneSetInstanceMetadata(scene, object_handle, metadata); }
+template<> inline uint32_t gfxSceneGetObjectCount<GfxMeshInstance>(GfxScene scene) { return gfxSceneGetMeshInstanceCount(scene); }
+template<> inline GfxMeshInstance const *gfxSceneGetObjects<GfxMeshInstance>(GfxScene scene) { return gfxSceneGetMeshInstances(scene); }
+template<> inline GfxMeshInstance *gfxSceneGetObject<GfxMeshInstance>(GfxScene scene, uint64_t object_handle) { return gfxSceneGetMeshInstance(scene, object_handle); }
+template<> inline GfxRef<GfxMeshInstance> gfxSceneGetObjectHandle<GfxMeshInstance>(GfxScene scene, uint32_t object_index) { return gfxSceneGetMeshInstanceHandle(scene, object_index); }
+template<> inline GfxMetadata const &gfxSceneGetObjectMetadata<GfxMeshInstance>(GfxScene scene, uint64_t object_handle) { return gfxSceneGetMeshInstanceMetadata(scene, object_handle); }
+template<> inline bool gfxSceneSetObjectMetadata<GfxMeshInstance>(GfxScene scene, uint64_t object_handle, GfxMetadata const &metadata) { return gfxSceneSetMeshInstanceMetadata(scene, object_handle, metadata); }
+
+template<> inline uint32_t gfxSceneGetObjectCount<GfxRenderInstance>(GfxScene scene) { return gfxSceneGetRenderInstanceCount(scene); }
+template<> inline GfxRenderInstance const* gfxSceneGetObjects<GfxRenderInstance>(GfxScene scene) { return gfxSceneGetRenderInstances(scene); }
+template<> inline GfxRenderInstance* gfxSceneGetObject<GfxRenderInstance>(GfxScene scene, uint64_t object_handle) { return gfxSceneGetRenderInstance(scene, object_handle); }
+template<> inline GfxRef<GfxRenderInstance> gfxSceneGetObjectHandle<GfxRenderInstance>(GfxScene scene, uint32_t object_index) { return gfxSceneGetRenderInstanceHandle(scene, object_index); }
+template<> inline GfxMetadata const& gfxSceneGetObjectMetadata<GfxRenderInstance>(GfxScene scene, uint64_t object_handle) { return gfxSceneGetRenderInstanceMetadata(scene, object_handle); }
+template<> inline bool gfxSceneSetObjectMetadata<GfxRenderInstance>(GfxScene scene, uint64_t object_handle, GfxMetadata const& metadata) { return gfxSceneSetRenderInstanceMetadata(scene, object_handle, metadata); }
 
 template<typename TYPE> uint32_t gfxSceneGetObjectCount(GfxScene) { static_assert(std::is_void_v<TYPE>, "Cannot get object count for unsupported object type"); }
 template<typename TYPE> TYPE const *gfxSceneGetObjects(GfxScene) { static_assert(std::is_void_v<TYPE>, "Cannot get object list for unsupported object type"); }

--- a/gfx_scene.h
+++ b/gfx_scene.h
@@ -434,6 +434,7 @@ GfxInstance *gfxSceneGetInstance(GfxScene scene, uint64_t instance_handle);
 GfxRef<GfxInstance> gfxSceneGetInstanceHandle(GfxScene scene, uint32_t instance_index);
 GfxMetadata const &gfxSceneGetInstanceMetadata(GfxScene scene, uint64_t instance_handle);
 bool gfxSceneSetInstanceMetadata(GfxScene scene, uint64_t instance_handle, GfxMetadata const &metadata);
+std::vector<std::vector<uint64_t>> gfxSceneGetInstancesBySameTransform(GfxScene scene);
 
 //!
 //! Template specializations.


### PR DESCRIPTION
This PR introduces new api function `gfxRaytracingPrimitiveBuildBatch` which allows to pack multiple `GfxRaytracingPrimitive` into a single BLAS during build.
In order to properly group meshes into BLASes a new object type was introduced - `GfxRenderInstance`. It stores all meshes that have the same global transform. `GfxInstance` was renamed to `GfxMeshInstance` for clarity.
New api usage example:
```c++
for (uint32_t i = 0U, instanceID = 0U; i < gfxSceneGetRenderInstanceCount(scene); ++i)
{
    GfxRenderInstance const &render_instance = gfxSceneGetRenderInstances(scene)[i];
    std::vector<GfxRaytracingPrimitiveBatchElement> batch;
    
    for (size_t j = 0U; j < render_instance.instances.size(); ++j)
    {
        GfxRef<GfxMeshInstance> const &mesh_instance = render_instance.instances[j];
        GfxRaytracingPrimitive primitive = gfxCreateRaytracingPrimitive(gfx, acceleration_structure);
        glm::mat4 const row_major_transform = transpose(render_instance.transform);
        gfxRaytracingPrimitiveSetTransform(gfx, primitive, &row_major_transform[0][0]);
        gfxRaytracingPrimitiveSetInstanceID(gfx, primitive, instanceID);
        
        GfxRaytracingPrimitiveBatchElement element = {};
        element.primitive     = primitive;
        element.index_buffer  = index_buffer;
        element.vertex_buffer = vertex_buffer;
        element.vertex_stride = 0U;
        element.flags         = isOpaque(mesh_instance->material) ? kGfxBuildRaytracingPrimitiveFlag_Opaque : 0U;
        
        batch.push_back(element);
    }
    
    if (!batch.empty())
    {
        gfxRaytracingPrimitiveBuildBatch(gfx, batch.data(), batch.size());
    }
    
    instanceID += static_cast<uint32_t>(render_instance.instances.size());
}

gfxAccelerationStructureUpdate(gfx, acceleration_structure);
```