### PR TITLE
BVH Compaction support

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -7499,7 +7499,7 @@ private:
     {
         constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
         GFX_ASSERT(gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles); // should never happen
-        if (update && (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) == 0)
+        if(update && (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) == 0)
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a non-updateable raytracing primitive object");
         if(gfx_raytracing_primitive.triangles_.index_stride_ != 0 && !buffer_handles_.has_handle(gfx_raytracing_primitive.triangles_.index_buffer_.handle))
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid index buffer object");
@@ -7542,15 +7542,15 @@ private:
         blas_inputs.pGeometryDescs = &geometry_desc;
         if(update)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
-        if (allow_compaction)
+        if(allow_compaction)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
-        if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) != 0)
+        if((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
-        if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastTrace) != 0)
+        if((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastTrace) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
-        else if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastBuild) != 0)
+        else if((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastBuild) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
-        if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_MinMemory) != 0)
+        if((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_MinMemory) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY;
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO blas_info = {};
         dxr_device_->GetRaytracingAccelerationStructurePrebuildInfo(&blas_inputs, &blas_info);
@@ -7572,9 +7572,9 @@ private:
             if(!gfx_raytracing_primitive.triangles_.bvh_buffer_)
                 return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create raytracing primitive buffer");
         }
-        if (allow_compaction)
+        if(allow_compaction)
         {
-            if (!gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_)
+            if(!gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_)
             {
                 gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_None);
                 gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_Read);
@@ -7587,7 +7587,7 @@ private:
         }
         else
         {
-            if (gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_)
+            if(gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_)
             {
                 destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_);
                 destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_);
@@ -7615,14 +7615,14 @@ private:
         build_desc.ScratchAccelerationStructureData = gfx_scratch_buffer.resource_->GetGPUVirtualAddress() + gfx_scratch_buffer.data_offset_;
         GFX_ASSERT(dxr_command_list_ != nullptr);   // should never happen
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC postbuild_info = {};
-        if (allow_compaction)
+        if(allow_compaction)
         {
             Buffer& compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
             postbuild_info.DestBuffer = compact_size_buffer.resource_->GetGPUVirtualAddress();
             postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
         }
         dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, allow_compaction ? 1 : 0, allow_compaction ? &postbuild_info : nullptr);
-        if (allow_compaction)
+        if(allow_compaction)
         {
             Buffer& dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
             Buffer& src = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
@@ -7633,7 +7633,7 @@ private:
             D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
             memcpy(&compact_size_desc, dst.data_, compact_size);
             const size_t old_size = gfx_raytracing_primitive.triangles_.bvh_buffer_.getSize();
-            if (compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+            if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
             {
                 GFX_SET_ERROR(kGfxResult_DeviceError, "Can't readback AS size. Possible sync issue.");
                 return kGfxResult_NoError; // Should we return an error here? Or do we just continue normally?
@@ -7656,7 +7656,7 @@ private:
     {
         constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
         GFX_ASSERT(gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Procedural); // should never happen
-        if (update && (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) == 0)
+        if(update && (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) == 0)
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a non-updateable raytracing primitive object");
         if(!buffer_handles_.has_handle(gfx_raytracing_primitive.procedural_.procedural_buffer_.handle))
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid procedural buffer object");
@@ -7686,15 +7686,15 @@ private:
         blas_inputs.pGeometryDescs = &geometry_desc;
         if(update)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
-        if (allow_compaction)
+        if(allow_compaction)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
-        if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) != 0)
+        if((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
-        if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastTrace) != 0)
+        if((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastTrace) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
-        else if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastBuild) != 0)
+        else if((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastBuild) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
-        if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_MinMemory) != 0)
+        if((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_MinMemory) != 0)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY;
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO blas_info = {};
         dxr_device_->GetRaytracingAccelerationStructurePrebuildInfo(&blas_inputs, &blas_info);
@@ -7716,9 +7716,9 @@ private:
             if(!gfx_raytracing_primitive.procedural_.bvh_buffer_)
                 return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create raytracing primitive buffer");
         }
-        if (allow_compaction)
+        if(allow_compaction)
         {
-            if (!gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_)
+            if(!gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_)
             {
                 gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_None);
                 gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_Read);
@@ -7731,7 +7731,7 @@ private:
         }
         else
         {
-            if (gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_)
+            if(gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_)
             {
                 destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_);
                 destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_);
@@ -7757,14 +7757,14 @@ private:
         build_desc.ScratchAccelerationStructureData = gfx_scratch_buffer.resource_->GetGPUVirtualAddress() + gfx_scratch_buffer.data_offset_;
         GFX_ASSERT(dxr_command_list_ != nullptr);   // should never happen
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC postbuild_info = {};
-        if (allow_compaction)
+        if(allow_compaction)
         {
             Buffer& compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
             postbuild_info.DestBuffer = compact_size_buffer.resource_->GetGPUVirtualAddress();
             postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
         }
         dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, allow_compaction ? 1 : 0, allow_compaction ? &postbuild_info : nullptr);
-        if (allow_compaction)
+        if(allow_compaction)
         {
             Buffer& dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
             Buffer& src = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_];
@@ -7775,7 +7775,7 @@ private:
             D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
             memcpy(&compact_size_desc, dst.data_, compact_size);
             const size_t old_size = gfx_raytracing_primitive.procedural_.bvh_buffer_.getSize();
-            if (compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+            if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
             {
                 GFX_SET_ERROR(kGfxResult_DeviceError, "Can't readback AS size. Possible sync issue.");
                 return kGfxResult_NoError; // Should we return an error here? Or do we just continue normally?

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -89,6 +89,8 @@ class GfxInternal
 {
     GFX_NON_COPYABLE(GfxInternal);
 
+	uint64_t finish_calls_counter_ = 0;
+
     HWND window_ = {};
     uint32_t window_width_ = 0;
     uint32_t window_height_ = 0;
@@ -477,7 +479,8 @@ class GfxInternal
             GfxBuffer bvh_buffer_ = {};
             GfxBuffer bvh_compact_size_buffer_ = {};
             GfxBuffer bvh_compact_size_readback_buffer_ = {};
-            uint64_t bvh_data_size_ = 0;
+			uint64_t finish_calls_state = 0; // Used to detect whether `finish()` was called in between build & compact operations
+			uint64_t bvh_data_size_ = 0;
             uint32_t index_stride_ = 0;
             GfxBuffer index_buffer_ = {};
             uint32_t vertex_stride_ = 0;
@@ -496,6 +499,7 @@ class GfxInternal
             GfxBuffer bvh_buffer_ = {};
             GfxBuffer bvh_compact_size_buffer_ = {};
             GfxBuffer bvh_compact_size_readback_buffer_ = {};
+			uint64_t finish_calls_state = 0; // Used to detect whether `finish()` was called in between build & compact operations
             uint64_t bvh_data_size_ = 0;
             uint32_t procedural_stride_ = 0;
             GfxBuffer procedural_buffer_ = {};
@@ -2721,6 +2725,16 @@ public:
         return buildRaytracingPrimitive(raytracing_primitive, gfx_raytracing_primitive, false);
     }
 
+	GfxResult compactRaytracingPrimitive(GfxRaytracingPrimitive const& raytracing_primitive)
+	{
+		if(dxr_device_ == nullptr)
+			return kGfxResult_InvalidOperation; // avoid spamming console output
+		if(!raytracing_primitive_handles_.has_handle(raytracing_primitive.handle))
+			return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot compact geometry of an invalid raytracing primitive object");
+		RaytracingPrimitive& gfx_raytracing_primitive = raytracing_primitives_[raytracing_primitive];
+		return compactRaytracingPrimitive(gfx_raytracing_primitive);
+	}
+
     GfxResult setRaytracingPrimitiveTransform(GfxRaytracingPrimitive const &raytracing_primitive, float const *row_major_4x4_transform)
     {
         if(dxr_device_ == nullptr)
@@ -4872,7 +4886,8 @@ public:
         command_list_->Reset(command_allocators_[fence_index_], nullptr);
         resetState();   // re-install state
         decayResourceState();
-        return kGfxResult_NoError;
+		finish_calls_counter_++;
+		return kGfxResult_NoError;
     }
 
     inline ID3D12Device *getDevice() const
@@ -7495,6 +7510,85 @@ private:
         return kGfxResult_NoError;
     }
 
+	GfxResult compactRaytracingPrimitiveTriangles(RaytracingPrimitive& gfx_raytracing_primitive)
+	{
+		constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
+		bool const allow_compaction = (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
+		if(!allow_compaction)
+			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
+		if(gfx_raytracing_primitive.procedural_.finish_calls_state >= finish_calls_counter_)
+			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet. Please, call `gfxFinish()` and try again");
+		Buffer& dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
+		D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
+		memcpy(&compact_size_desc, dst.data_, compact_size);
+		const size_t old_size = gfx_raytracing_primitive.triangles_.bvh_buffer_.getSize();
+		if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+		{
+			GFX_SET_ERROR(kGfxResult_InternalError, "Can't readback compacted AS size. Possible sync issue.");
+			return kGfxResult_InternalError; // Should we return an error here? Or do we just continue normally?
+		}
+		GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+		Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
+		Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.triangles_.bvh_buffer_];
+		gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.triangles_.bvh_buffer_.getName());
+		SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
+		D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
+		D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
+		dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
+		destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_buffer_);
+		gfx_raytracing_primitive.triangles_.bvh_buffer_ = gfx_compacted_bvh_buffer;
+		return kGfxResult_NoError;
+	}
+
+	GfxResult compactRaytracingPrimitiveProcedural(RaytracingPrimitive& gfx_raytracing_primitive)
+	{
+		constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
+		bool const allow_compaction = (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
+		if(!allow_compaction)
+			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
+		if(gfx_raytracing_primitive.procedural_.finish_calls_state >= finish_calls_counter_)
+			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet. Please, call `gfxFinish()` and try again");
+		Buffer& dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
+		D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
+		memcpy(&compact_size_desc, dst.data_, compact_size);
+		const size_t old_size = gfx_raytracing_primitive.procedural_.bvh_buffer_.getSize();
+		if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+		{
+			GFX_SET_ERROR(kGfxResult_InternalError, "Can't readback compacted AS size. Possible sync issue.");
+			return kGfxResult_InternalError; // Should we return an error here? Or do we just continue normally?
+		}
+		GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+		Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
+		Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.procedural_.bvh_buffer_];
+		gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.procedural_.bvh_buffer_.getName());
+		SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
+		D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
+		D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
+		dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
+		destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_buffer_);
+		gfx_raytracing_primitive.procedural_.bvh_buffer_ = gfx_compacted_bvh_buffer;
+		return kGfxResult_NoError;
+	}
+
+	GfxResult compactRaytracingPrimitive(RaytracingPrimitive& gfx_raytracing_primitive)
+	{
+		switch(gfx_raytracing_primitive.type_)
+		{
+		case RaytracingPrimitive::kType_Triangles:
+			GFX_TRY(compactRaytracingPrimitiveTriangles(gfx_raytracing_primitive));
+			break;
+		case RaytracingPrimitive::kType_Instance:
+			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot compact an instance raytracing primitive");
+		case RaytracingPrimitive::kType_Procedural:
+			GFX_TRY(compactRaytracingPrimitiveProcedural(gfx_raytracing_primitive));
+			break;
+		default:
+			GFX_ASSERTMSG(0, "An invalid raytracing primitive type was supplied");
+			break;
+		}
+		return kGfxResult_NoError;
+	}
+
     GfxResult buildRaytracingPrimitiveTriangles(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive, bool update)
     {
         constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
@@ -7629,25 +7723,7 @@ private:
             transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
             submitPipelineBarriers();
             dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
-            finish();
-            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
-            memcpy(&compact_size_desc, dst.data_, compact_size);
-            const size_t old_size = gfx_raytracing_primitive.triangles_.bvh_buffer_.getSize();
-            if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
-            {
-                GFX_SET_ERROR(kGfxResult_DeviceError, "Can't readback AS size. Possible sync issue.");
-                return kGfxResult_NoError; // Should we return an error here? Or do we just continue normally?
-            }
-            GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
-            Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
-            Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.triangles_.bvh_buffer_];
-            gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.triangles_.bvh_buffer_.getName());
-            SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
-            D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
-            D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
-            dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
-            destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_buffer_);
-            gfx_raytracing_primitive.triangles_.bvh_buffer_ = gfx_compacted_bvh_buffer;
+			gfx_raytracing_primitive.triangles_.finish_calls_state = finish_calls_counter_;
         }
         return kGfxResult_NoError;
     }
@@ -7771,26 +7847,8 @@ private:
             transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
             submitPipelineBarriers();
             dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
-            finish();
-            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
-            memcpy(&compact_size_desc, dst.data_, compact_size);
-            const size_t old_size = gfx_raytracing_primitive.procedural_.bvh_buffer_.getSize();
-            if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
-            {
-                GFX_SET_ERROR(kGfxResult_DeviceError, "Can't readback AS size. Possible sync issue.");
-                return kGfxResult_NoError; // Should we return an error here? Or do we just continue normally?
-            }
-            GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
-            Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
-            Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.procedural_.bvh_buffer_];
-            gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.procedural_.bvh_buffer_.getName());
-            SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
-            D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
-            D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
-            dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
-            destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_buffer_);
-            gfx_raytracing_primitive.procedural_.bvh_buffer_ = gfx_compacted_bvh_buffer;
-        }
+			gfx_raytracing_primitive.triangles_.finish_calls_state = finish_calls_counter_;
+		}
         return kGfxResult_NoError;
     }
 
@@ -10610,6 +10668,13 @@ GfxResult gfxRaytracingPrimitiveBuildProcedural(GfxContext context, GfxRaytracin
     GfxInternal *gfx = GfxInternal::GetGfx(context);
     if(!gfx) return kGfxResult_InvalidParameter;
     return gfx->buildRaytracingPrimitiveProcedural(raytracing_primitive, aabb_buffer, aabb_stride, build_flags);
+}
+
+GfxResult gfxRaytracingPrimitiveCompact(GfxContext context, GfxRaytracingPrimitive raytracing_primitive)
+{
+	GfxInternal* gfx = GfxInternal::GetGfx(context);
+	if (!gfx) return kGfxResult_InvalidParameter;
+	return gfx->compactRaytracingPrimitive(raytracing_primitive);
 }
 
 GfxResult gfxRaytracingPrimitiveSetTransform(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, float const *row_major_4x4_transform)

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -7499,6 +7499,8 @@ private:
     {
         constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
         GFX_ASSERT(gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles); // should never happen
+        if (update && (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) == 0)
+            return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a non-updateable raytracing primitive object");
         if(gfx_raytracing_primitive.triangles_.index_stride_ != 0 && !buffer_handles_.has_handle(gfx_raytracing_primitive.triangles_.index_buffer_.handle))
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid index buffer object");
         if(!buffer_handles_.has_handle(gfx_raytracing_primitive.triangles_.vertex_buffer_.handle))
@@ -7535,13 +7537,21 @@ private:
         bool const allow_compaction = (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
         D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS blas_inputs = {};
         blas_inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
-        blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+        blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
         blas_inputs.NumDescs = 1;
         blas_inputs.pGeometryDescs = &geometry_desc;
         if(update)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
         if (allow_compaction)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
+        if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+        if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastTrace) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
+        else if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastBuild) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+        if ((gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_MinMemory) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY;
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO blas_info = {};
         dxr_device_->GetRaytracingAccelerationStructurePrebuildInfo(&blas_inputs, &blas_info);
         uint64_t const scratch_data_size = GFX_MAX(blas_info.ScratchDataSizeInBytes, blas_info.UpdateScratchDataSizeInBytes);
@@ -7646,6 +7656,8 @@ private:
     {
         constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
         GFX_ASSERT(gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Procedural); // should never happen
+        if (update && (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) == 0)
+            return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a non-updateable raytracing primitive object");
         if(!buffer_handles_.has_handle(gfx_raytracing_primitive.procedural_.procedural_buffer_.handle))
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid procedural buffer object");
         GFX_ASSERT(gfx_raytracing_primitive.procedural_.procedural_stride_ > 0 && gfx_raytracing_primitive.procedural_.procedural_buffer_.size / gfx_raytracing_primitive.procedural_.procedural_stride_ <= 0xFFFFFFFFull);
@@ -7669,13 +7681,21 @@ private:
         bool const allow_compaction = (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
         D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS blas_inputs = {};
         blas_inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
-        blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+        blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
         blas_inputs.NumDescs = 1;
         blas_inputs.pGeometryDescs = &geometry_desc;
         if(update)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
         if (allow_compaction)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
+        if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Updateable) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+        if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastTrace) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
+        else if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_FastBuild) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+        if ((gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_MinMemory) != 0)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY;
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO blas_info = {};
         dxr_device_->GetRaytracingAccelerationStructurePrebuildInfo(&blas_inputs, &blas_info);
         uint64_t const scratch_data_size = GFX_MAX(blas_info.ScratchDataSizeInBytes, blas_info.UpdateScratchDataSizeInBytes);

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -475,6 +475,8 @@ class GfxInternal
         {
             uint32_t build_flags_ = 0;
             GfxBuffer bvh_buffer_ = {};
+            GfxBuffer bvh_compact_size_buffer_ = {};
+            GfxBuffer bvh_compact_size_readback_buffer_ = {};
             uint64_t bvh_data_size_ = 0;
             uint32_t index_stride_ = 0;
             GfxBuffer index_buffer_ = {};
@@ -492,6 +494,8 @@ class GfxInternal
         {
             uint32_t build_flags_ = 0;
             GfxBuffer bvh_buffer_ = {};
+            GfxBuffer bvh_compact_size_buffer_ = {};
+            GfxBuffer bvh_compact_size_readback_buffer_ = {};
             uint64_t bvh_data_size_ = 0;
             uint32_t procedural_stride_ = 0;
             GfxBuffer procedural_buffer_ = {};
@@ -6012,6 +6016,8 @@ private:
         {
         case RaytracingPrimitive::kType_Triangles:
             destroyBuffer(raytracing_primitive.triangles_.bvh_buffer_);
+            destroyBuffer(raytracing_primitive.triangles_.bvh_compact_size_buffer_);
+            destroyBuffer(raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_);
             destroyBuffer(raytracing_primitive.triangles_.index_buffer_);
             destroyBuffer(raytracing_primitive.triangles_.vertex_buffer_);
             break;
@@ -6019,6 +6025,8 @@ private:
             break;  // nothing to collect on instanced primitives
         case RaytracingPrimitive::kType_Procedural:
             destroyBuffer(raytracing_primitive.procedural_.bvh_buffer_);
+            destroyBuffer(raytracing_primitive.procedural_.bvh_compact_size_buffer_);
+            destroyBuffer(raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_);
             destroyBuffer(raytracing_primitive.procedural_.procedural_buffer_);
             break;
         default:
@@ -7489,6 +7497,7 @@ private:
 
     GfxResult buildRaytracingPrimitiveTriangles(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive, bool update)
     {
+        constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
         GFX_ASSERT(gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Triangles); // should never happen
         if(gfx_raytracing_primitive.triangles_.index_stride_ != 0 && !buffer_handles_.has_handle(gfx_raytracing_primitive.triangles_.index_buffer_.handle))
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid index buffer object");
@@ -7523,6 +7532,7 @@ private:
         geometry_desc.Triangles.VertexCount = (uint32_t)(gfx_raytracing_primitive.triangles_.vertex_buffer_.size / gfx_raytracing_primitive.triangles_.vertex_stride_);
         geometry_desc.Triangles.VertexBuffer.StartAddress = gfx_vertex_buffer.resource_->GetGPUVirtualAddress() + gfx_vertex_buffer.data_offset_;
         geometry_desc.Triangles.VertexBuffer.StrideInBytes = gfx_raytracing_primitive.triangles_.vertex_stride_;
+        bool const allow_compaction = (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
         D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS blas_inputs = {};
         blas_inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
         blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
@@ -7530,6 +7540,8 @@ private:
         blas_inputs.pGeometryDescs = &geometry_desc;
         if(update)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+        if (allow_compaction)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO blas_info = {};
         dxr_device_->GetRaytracingAccelerationStructurePrebuildInfo(&blas_inputs, &blas_info);
         uint64_t const scratch_data_size = GFX_MAX(blas_info.ScratchDataSizeInBytes, blas_info.UpdateScratchDataSizeInBytes);
@@ -7550,6 +7562,29 @@ private:
             if(!gfx_raytracing_primitive.triangles_.bvh_buffer_)
                 return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create raytracing primitive buffer");
         }
+        if (allow_compaction)
+        {
+            if (!gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_)
+            {
+                gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_None);
+                gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_Read);
+                // We could pass `D3D12_RESOURCE_STATE_UNORDERED_ACCESS` to `createBuffer` directly,
+                // but then DX12 spams warnings about "Ignoring InitialState D3D12_RESOURCE_STATE_UNORDERED_ACCESS".
+                // So, in order to suppress them, we do this.
+                Buffer& buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
+                transitionResource(buffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, kTransitionType_Implicit);
+            }
+        }
+        else
+        {
+            if (gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_)
+            {
+                destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_);
+                destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_);
+                gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_ = {};
+                gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_ = {};
+            }
+        }
         gfx_raytracing_primitive.triangles_.bvh_data_size_ = (uint64_t)blas_info.ResultDataMaxSizeInBytes;
         GFX_ASSERT(buffer_handles_.has_handle(gfx_raytracing_primitive.triangles_.bvh_buffer_.handle));
         GFX_ASSERT(buffer_handles_.has_handle(raytracing_scratch_buffer_.handle));
@@ -7569,12 +7604,47 @@ private:
             build_desc.SourceAccelerationStructureData = gfx_buffer.resource_->GetGPUVirtualAddress() + gfx_buffer.data_offset_;
         build_desc.ScratchAccelerationStructureData = gfx_scratch_buffer.resource_->GetGPUVirtualAddress() + gfx_scratch_buffer.data_offset_;
         GFX_ASSERT(dxr_command_list_ != nullptr);   // should never happen
-        dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, 0, nullptr);
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC postbuild_info = {};
+        if (allow_compaction)
+        {
+            Buffer& compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
+            postbuild_info.DestBuffer = compact_size_buffer.resource_->GetGPUVirtualAddress();
+            postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
+        }
+        dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, allow_compaction ? 1 : 0, allow_compaction ? &postbuild_info : nullptr);
+        if (allow_compaction)
+        {
+            Buffer& dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
+            Buffer& src = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
+            transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
+            submitPipelineBarriers();
+            dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
+            finish();
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
+            memcpy(&compact_size_desc, dst.data_, compact_size);
+            const size_t old_size = gfx_raytracing_primitive.triangles_.bvh_buffer_.getSize();
+            if (compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+            {
+                GFX_SET_ERROR(kGfxResult_DeviceError, "Can't readback AS size. Possible sync issue.");
+                return kGfxResult_NoError; // Should we return an error here? Or do we just continue normally?
+            }
+            GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+            Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
+            Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.triangles_.bvh_buffer_];
+            gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.triangles_.bvh_buffer_.getName());
+            SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
+            D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
+            D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
+            dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
+            destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_buffer_);
+            gfx_raytracing_primitive.triangles_.bvh_buffer_ = gfx_compacted_bvh_buffer;
+        }
         return kGfxResult_NoError;
     }
 
     GfxResult buildRaytracingPrimitiveProcedural(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive, bool update)
     {
+        constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
         GFX_ASSERT(gfx_raytracing_primitive.type_ == RaytracingPrimitive::kType_Procedural); // should never happen
         if(!buffer_handles_.has_handle(gfx_raytracing_primitive.procedural_.procedural_buffer_.handle))
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot update a raytracing primitive that's pointing to an invalid procedural buffer object");
@@ -7596,6 +7666,7 @@ private:
         geometry_desc.AABBs.AABBCount = 1;
         geometry_desc.AABBs.AABBs.StrideInBytes = sizeof(D3D12_RAYTRACING_AABB);
         geometry_desc.AABBs.AABBs.StartAddress = gfx_aabb_buffer.resource_->GetGPUVirtualAddress() + gfx_aabb_buffer.data_offset_;
+        bool const allow_compaction = (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
         D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS blas_inputs = {};
         blas_inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
         blas_inputs.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
@@ -7603,6 +7674,8 @@ private:
         blas_inputs.pGeometryDescs = &geometry_desc;
         if(update)
             blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+        if (allow_compaction)
+            blas_inputs.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO blas_info = {};
         dxr_device_->GetRaytracingAccelerationStructurePrebuildInfo(&blas_inputs, &blas_info);
         uint64_t const scratch_data_size = GFX_MAX(blas_info.ScratchDataSizeInBytes, blas_info.UpdateScratchDataSizeInBytes);
@@ -7623,6 +7696,29 @@ private:
             if(!gfx_raytracing_primitive.procedural_.bvh_buffer_)
                 return GFX_SET_ERROR(kGfxResult_OutOfMemory, "Unable to create raytracing primitive buffer");
         }
+        if (allow_compaction)
+        {
+            if (!gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_)
+            {
+                gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_None);
+                gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_ = createBuffer(compact_size, nullptr, kGfxCpuAccess_Read);
+                // We could pass `D3D12_RESOURCE_STATE_UNORDERED_ACCESS` to `createBuffer` directly,
+                // but then DX12 spams warnings about "Ignoring InitialState D3D12_RESOURCE_STATE_UNORDERED_ACCESS".
+                // So, in order to suppress them, we do this.
+                Buffer& buffer = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_];
+                transitionResource(buffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, kTransitionType_Implicit);
+            }
+        }
+        else
+        {
+            if (gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_)
+            {
+                destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_);
+                destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_);
+                gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_ = {};
+                gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_ = {};
+            }
+        }
         gfx_raytracing_primitive.procedural_.bvh_data_size_ = (uint64_t)blas_info.ResultDataMaxSizeInBytes;
         GFX_ASSERT(buffer_handles_.has_handle(gfx_raytracing_primitive.procedural_.bvh_buffer_.handle));
         GFX_ASSERT(buffer_handles_.has_handle(raytracing_scratch_buffer_.handle));
@@ -7640,7 +7736,41 @@ private:
             build_desc.SourceAccelerationStructureData = gfx_buffer.resource_->GetGPUVirtualAddress() + gfx_buffer.data_offset_;
         build_desc.ScratchAccelerationStructureData = gfx_scratch_buffer.resource_->GetGPUVirtualAddress() + gfx_scratch_buffer.data_offset_;
         GFX_ASSERT(dxr_command_list_ != nullptr);   // should never happen
-        dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, 0, nullptr);
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC postbuild_info = {};
+        if (allow_compaction)
+        {
+            Buffer& compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
+            postbuild_info.DestBuffer = compact_size_buffer.resource_->GetGPUVirtualAddress();
+            postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
+        }
+        dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, allow_compaction ? 1 : 0, allow_compaction ? &postbuild_info : nullptr);
+        if (allow_compaction)
+        {
+            Buffer& dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
+            Buffer& src = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_];
+            transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
+            submitPipelineBarriers();
+            dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
+            finish();
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
+            memcpy(&compact_size_desc, dst.data_, compact_size);
+            const size_t old_size = gfx_raytracing_primitive.procedural_.bvh_buffer_.getSize();
+            if (compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+            {
+                GFX_SET_ERROR(kGfxResult_DeviceError, "Can't readback AS size. Possible sync issue.");
+                return kGfxResult_NoError; // Should we return an error here? Or do we just continue normally?
+            }
+            GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+            Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
+            Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.procedural_.bvh_buffer_];
+            gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.procedural_.bvh_buffer_.getName());
+            SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
+            D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
+            D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
+            dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
+            destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_buffer_);
+            gfx_raytracing_primitive.procedural_.bvh_buffer_ = gfx_compacted_bvh_buffer;
+        }
         return kGfxResult_NoError;
     }
 

--- a/gfx.h
+++ b/gfx.h
@@ -234,6 +234,7 @@ GfxResult gfxDestroyRaytracingPrimitive(GfxContext context, GfxRaytracingPrimiti
 GfxResult gfxRaytracingPrimitiveBuild(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer vertex_buffer, uint32_t vertex_stride = 0, GfxBuildRaytracingPrimitiveFlags build_flags = 0);
 GfxResult gfxRaytracingPrimitiveBuild(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer index_buffer, GfxBuffer vertex_buffer, uint32_t vertex_stride = 0, GfxBuildRaytracingPrimitiveFlags build_flags = 0);
 GfxResult gfxRaytracingPrimitiveBuildProcedural(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, GfxBuffer aabb_buffer, uint32_t aabb_stride = 0, GfxBuildRaytracingPrimitiveFlags build_flags = 0);
+GfxResult gfxRaytracingPrimitiveCompact(GfxContext context, GfxRaytracingPrimitive raytracing_primitive);
 
 GfxResult gfxRaytracingPrimitiveSetTransform(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, float const *row_major_4x4_transform);
 GfxResult gfxRaytracingPrimitiveSetInstanceID(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, uint32_t instance_id);   // retrieved through `ray_query.CommittedInstanceID()`

--- a/gfx.h
+++ b/gfx.h
@@ -211,7 +211,9 @@ uint64_t gfxAccelerationStructureGetDataSize(GfxContext context, GfxAcceleration
 
 enum GfxBuildRaytracingPrimitiveFlag
 {
-    kGfxBuildRaytracingPrimitiveFlag_Opaque = 1 << 0
+    kGfxBuildRaytracingPrimitiveFlag_None    = 0,
+    kGfxBuildRaytracingPrimitiveFlag_Opaque  = 1 << 0,
+    kGfxBuildRaytracingPrimitiveFlag_Compact = 1 << 1, // It's recommended to avoid compaction for dynamic geometry since compaction requires extra CPU-GPU sync
 };
 typedef uint32_t GfxBuildRaytracingPrimitiveFlags;
 

--- a/gfx.h
+++ b/gfx.h
@@ -211,9 +211,13 @@ uint64_t gfxAccelerationStructureGetDataSize(GfxContext context, GfxAcceleration
 
 enum GfxBuildRaytracingPrimitiveFlag
 {
-    kGfxBuildRaytracingPrimitiveFlag_None    = 0,
-    kGfxBuildRaytracingPrimitiveFlag_Opaque  = 1 << 0,
-    kGfxBuildRaytracingPrimitiveFlag_Compact = 1 << 1, // It's recommended to avoid compaction for dynamic geometry since compaction requires extra CPU-GPU sync
+    kGfxBuildRaytracingPrimitiveFlag_None       = 0,
+    kGfxBuildRaytracingPrimitiveFlag_Opaque     = 1 << 0,
+    kGfxBuildRaytracingPrimitiveFlag_Compact    = 1 << 1, // It's recommended to avoid compaction for dynamic geometry since compaction requires extra CPU-GPU sync
+    kGfxBuildRaytracingPrimitiveFlag_Updateable = 1 << 2,
+    kGfxBuildRaytracingPrimitiveFlag_FastTrace  = 1 << 3,
+    kGfxBuildRaytracingPrimitiveFlag_FastBuild  = 1 << 4,
+    kGfxBuildRaytracingPrimitiveFlag_MinMemory  = 1 << 5,
 };
 typedef uint32_t GfxBuildRaytracingPrimitiveFlags;
 


### PR DESCRIPTION
Adds BVH compaction support.

It requires extra CPU-GPU sync, so it's not recommended for dynamic geometry.
We wait for `BuildRaytracingAccelerationStructure` to finish, readback the compacted size, allocate a new buffer, execute `CopyRaytracingAccelerationStructure` to copy BVH to a new compacted buffer, and delete the old one.

It seems like compaction saves ~100mb of VRAM on `Bistro` and `Toyshop` scenes