### PR TITLE
Fix 16-bit texture imports

### DIFF
--- a/gfx_scene.cpp
+++ b/gfx_scene.cpp
@@ -2991,6 +2991,7 @@ private:
         else
         {
             uint16_t *data = (uint16_t*)image_ref->data.data();
+            uint16_t const *image_data_16bit = (uint16_t const *)image_data;
             uint16_t alpha_check = 65535;   // check alpha
             for(int32_t y = 0; y < image_height; ++y)
                 for(int32_t x = 0; x < image_width; ++x)
@@ -2998,7 +2999,7 @@ private:
                     {
                         int32_t const dst_index = (int32_t)resolved_channel_count * (x + y * image_width) + k;
                         int32_t const src_index = channel_count * (x + y * image_width) + k;
-                        uint16_t const source = (k < channel_count ? image_data[src_index] : (uint16_t)65535);
+                        uint16_t const source = (k < channel_count ? image_data_16bit[src_index] : (uint16_t)65535);
                         if(k == 3) alpha_check &= source;
                         data[dst_index] = source;
                     }


### PR DESCRIPTION
Original code tried to fetch 16-bit data from a 8-bit buffer without casting. Effectively this just loaded the first byte and casted it to `uint16_t`, leading to severe data loss.

To easily reproduce this issue, you can build this minimal example: [alexf-amd/GFX-debug](https://github.com/alexf-amd/GFX-debug).
Then, to try out the fix you can simply edit [CMakeLists.txt](https://github.com/alexf-amd/GFX-debug/blob/main/CMakeLists.txt#L7) to pull the `alexf/fix-16bit-textures` branch of GFX.