### PR TITLE
Add mutexes around filesystem operations

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -9948,7 +9948,7 @@ private:
                         for(size_t i = max_cached_files; i < bytecode_files.size(); ++i)
                             std::filesystem::remove(bytecode_files[i], ec);
                     }
-                    if (reflection_files.size() > max_cached_files)
+                    if(reflection_files.size() > max_cached_files)
                     {
                         std::sort(reflection_files.begin(), reflection_files.end(),
                             [&ec](std::filesystem::path const &a, std::filesystem::path const &b) {

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -9880,19 +9880,24 @@ private:
                 fclose(fd); // write out PDB for shader debugging
             }
             // Delete older pdb files
-            std::filesystem::directory_iterator const end;
-            std::vector<std::filesystem::path>        pdb_files;
-            std::error_code                           ec, ec2;
-            for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_pdb_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
-                if(is_regular_file(*iter, ec))
-                    if(iter->path().extension() == ".pdb")
-                        pdb_files.emplace_back(*iter);
-            if(pdb_files.size() > max_cached_files)
+            static std::atomic_bool shader_pdb_cleanup;
+            if(bool expected = false; !shader_pdb_cleanup.compare_exchange_strong(expected, true))
             {
-                std::sort(pdb_files.begin(), pdb_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
-                    return last_write_time(a, ec) > last_write_time(b, ec); });
-                for(size_t i = max_cached_files; i < pdb_files.size(); ++i)
-                    std::filesystem::remove(pdb_files[i], ec);
+                std::filesystem::directory_iterator const end;
+                std::vector<std::filesystem::path>        pdb_files;
+                std::error_code                           ec, ec2;
+                for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_pdb_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
+                    if(is_regular_file(*iter, ec))
+                        if(iter->path().extension() == ".pdb")
+                            pdb_files.emplace_back(*iter);
+                if(pdb_files.size() > max_cached_files)
+                {
+                    std::sort(pdb_files.begin(), pdb_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
+                        return last_write_time(a, ec) > last_write_time(b, ec); });
+                    for(size_t i = max_cached_files; i < pdb_files.size(); ++i)
+                        std::filesystem::remove(pdb_files[i], ec);
+                }
+                shader_pdb_cleanup.exchange(false);
             }
         }
 
@@ -9924,32 +9929,37 @@ private:
                         fclose(fd); // write out reflection for shader caching
                     }
                     // Delete older cached files
-                    std::filesystem::directory_iterator const end;
-                    std::vector<std::filesystem::path>        bytecode_files;
-                    std::vector<std::filesystem::path>        reflection_files;
-                    std::error_code                           ec, ec2;
-                    for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_cache_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
-                        if(is_regular_file(*iter, ec))
+                    static std::atomic_bool shader_cache_cleanup;
+                    if(bool expected = false; !shader_cache_cleanup.compare_exchange_strong(expected, true))
+                    {
+                        std::filesystem::directory_iterator const end;
+                        std::vector<std::filesystem::path>        bytecode_files;
+                        std::vector<std::filesystem::path>        reflection_files;
+                        std::error_code                           ec, ec2;
+                        for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_cache_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
+                            if(is_regular_file(*iter, ec))
+                            {
+                                if(iter->path().extension() == ".bytecode")
+                                    bytecode_files.emplace_back(*iter);
+                                else if(iter->path().extension() == ".reflection")
+                                    reflection_files.emplace_back(*iter);
+                            }
+                        if(bytecode_files.size() > max_cached_files)
                         {
-                            if(iter->path().extension() == ".bytecode")
-                                bytecode_files.emplace_back(*iter);
-                            else if(iter->path().extension() == ".reflection")
-                                reflection_files.emplace_back(*iter);
-                        }
-                    if(bytecode_files.size() > max_cached_files)
-                    {
-                        std::sort(bytecode_files.begin(), bytecode_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
-                            return last_write_time(a, ec) > last_write_time(b, ec); });
-                        for(size_t i = max_cached_files; i < bytecode_files.size(); ++i)
-                            std::filesystem::remove(bytecode_files[i], ec);
-                    }
-                    if (reflection_files.size() > max_cached_files)
-                    {
-                        std::sort(reflection_files.begin(), reflection_files.end(),
-                            [&ec](std::filesystem::path const &a, std::filesystem::path const &b) {
+                            std::sort(bytecode_files.begin(), bytecode_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
                                 return last_write_time(a, ec) > last_write_time(b, ec); });
-                        for(size_t i = max_cached_files; i < reflection_files.size(); ++i)
-                            std::filesystem::remove(reflection_files[i], ec);
+                            for(size_t i = max_cached_files; i < bytecode_files.size(); ++i)
+                                std::filesystem::remove(bytecode_files[i], ec);
+                        }
+                        if (reflection_files.size() > max_cached_files)
+                        {
+                            std::sort(reflection_files.begin(), reflection_files.end(),
+                                [&ec](std::filesystem::path const &a, std::filesystem::path const &b) {
+                                    return last_write_time(a, ec) > last_write_time(b, ec); });
+                            for(size_t i = max_cached_files; i < reflection_files.size(); ++i)
+                                std::filesystem::remove(reflection_files[i], ec);
+                        }
+                        shader_cache_cleanup.exchange(false);
                     }
                 }
             }

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -32,6 +32,7 @@ SOFTWARE.
 #include <d3d12shader.h>        // shader reflection
 #include <dxgi1_6.h>            // IDXGIFactory6 + IDXGIOutput6
 #include <filesystem>
+#include <mutex>
 
 #ifdef __clang__
 #    pragma clang diagnostic push
@@ -9880,24 +9881,21 @@ private:
                 fclose(fd); // write out PDB for shader debugging
             }
             // Delete older pdb files
-            static std::atomic_bool shader_pdb_cleanup;
-            if(bool expected = false; !shader_pdb_cleanup.compare_exchange_strong(expected, true))
+            static std::mutex shader_pdb_cleanup;
+            std::scoped_lock<std::mutex> lock(shader_pdb_cleanup);
+            std::filesystem::directory_iterator const end;
+            std::vector<std::filesystem::path>        pdb_files;
+            std::error_code                           ec, ec2;
+            for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_pdb_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
+                if(is_regular_file(*iter, ec))
+                    if(iter->path().extension() == ".pdb")
+                        pdb_files.emplace_back(*iter);
+            if(pdb_files.size() > max_cached_files)
             {
-                std::filesystem::directory_iterator const end;
-                std::vector<std::filesystem::path>        pdb_files;
-                std::error_code                           ec, ec2;
-                for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_pdb_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
-                    if(is_regular_file(*iter, ec))
-                        if(iter->path().extension() == ".pdb")
-                            pdb_files.emplace_back(*iter);
-                if(pdb_files.size() > max_cached_files)
-                {
-                    std::sort(pdb_files.begin(), pdb_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
-                        return last_write_time(a, ec) > last_write_time(b, ec); });
-                    for(size_t i = max_cached_files; i < pdb_files.size(); ++i)
-                        std::filesystem::remove(pdb_files[i], ec);
-                }
-                shader_pdb_cleanup.exchange(false);
+                std::sort(pdb_files.begin(), pdb_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
+                    return last_write_time(a, ec) > last_write_time(b, ec); });
+                for(size_t i = max_cached_files; i < pdb_files.size(); ++i)
+                    std::filesystem::remove(pdb_files[i], ec);
             }
         }
 
@@ -9929,37 +9927,34 @@ private:
                         fclose(fd); // write out reflection for shader caching
                     }
                     // Delete older cached files
-                    static std::atomic_bool shader_cache_cleanup;
-                    if(bool expected = false; !shader_cache_cleanup.compare_exchange_strong(expected, true))
+                    static std::mutex shader_cache_cleanup;
+                    std::scoped_lock<std::mutex> lock(shader_cache_cleanup);
+                    std::filesystem::directory_iterator const end;
+                    std::vector<std::filesystem::path>        bytecode_files;
+                    std::vector<std::filesystem::path>        reflection_files;
+                    std::error_code                           ec, ec2;
+                    for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_cache_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
+                        if(is_regular_file(*iter, ec))
+                        {
+                            if(iter->path().extension() == ".bytecode")
+                                bytecode_files.emplace_back(*iter);
+                            else if(iter->path().extension() == ".reflection")
+                                reflection_files.emplace_back(*iter);
+                        }
+                    if(bytecode_files.size() > max_cached_files)
                     {
-                        std::filesystem::directory_iterator const end;
-                        std::vector<std::filesystem::path>        bytecode_files;
-                        std::vector<std::filesystem::path>        reflection_files;
-                        std::error_code                           ec, ec2;
-                        for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_cache_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
-                            if(is_regular_file(*iter, ec))
-                            {
-                                if(iter->path().extension() == ".bytecode")
-                                    bytecode_files.emplace_back(*iter);
-                                else if(iter->path().extension() == ".reflection")
-                                    reflection_files.emplace_back(*iter);
-                            }
-                        if(bytecode_files.size() > max_cached_files)
-                        {
-                            std::sort(bytecode_files.begin(), bytecode_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
+                        std::sort(bytecode_files.begin(), bytecode_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
+                            return last_write_time(a, ec) > last_write_time(b, ec); });
+                        for(size_t i = max_cached_files; i < bytecode_files.size(); ++i)
+                            std::filesystem::remove(bytecode_files[i], ec);
+                    }
+                    if (reflection_files.size() > max_cached_files)
+                    {
+                        std::sort(reflection_files.begin(), reflection_files.end(),
+                            [&ec](std::filesystem::path const &a, std::filesystem::path const &b) {
                                 return last_write_time(a, ec) > last_write_time(b, ec); });
-                            for(size_t i = max_cached_files; i < bytecode_files.size(); ++i)
-                                std::filesystem::remove(bytecode_files[i], ec);
-                        }
-                        if (reflection_files.size() > max_cached_files)
-                        {
-                            std::sort(reflection_files.begin(), reflection_files.end(),
-                                [&ec](std::filesystem::path const &a, std::filesystem::path const &b) {
-                                    return last_write_time(a, ec) > last_write_time(b, ec); });
-                            for(size_t i = max_cached_files; i < reflection_files.size(); ++i)
-                                std::filesystem::remove(reflection_files[i], ec);
-                        }
-                        shader_cache_cleanup.exchange(false);
+                        for(size_t i = max_cached_files; i < reflection_files.size(); ++i)
+                            std::filesystem::remove(reflection_files[i], ec);
                     }
                 }
             }

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -9882,16 +9882,17 @@ private:
             // Delete older pdb files
             std::filesystem::directory_iterator const end;
             std::vector<std::filesystem::path>        pdb_files;
-            for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_pdb_dir + shader_key_dir)}; iter != end; ++iter)
-                if(is_regular_file(*iter))
+            std::error_code                           ec, ec2;
+            for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_pdb_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
+                if(is_regular_file(*iter, ec))
                     if(iter->path().extension() == ".pdb")
                         pdb_files.emplace_back(*iter);
             if(pdb_files.size() > max_cached_files)
             {
-                std::sort(pdb_files.begin(), pdb_files.end(), [](const std::filesystem::path &a, const std::filesystem::path &b) {
-                    return last_write_time(a) > last_write_time(b); });
+                std::sort(pdb_files.begin(), pdb_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
+                    return last_write_time(a, ec) > last_write_time(b, ec); });
                 for(size_t i = max_cached_files; i < pdb_files.size(); ++i)
-                    std::filesystem::remove(pdb_files[i]);
+                    std::filesystem::remove(pdb_files[i], ec);
             }
         }
 
@@ -9926,8 +9927,9 @@ private:
                     std::filesystem::directory_iterator const end;
                     std::vector<std::filesystem::path>        bytecode_files;
                     std::vector<std::filesystem::path>        reflection_files;
-                    for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_cache_dir + shader_key_dir)}; iter != end; ++iter)
-                        if(is_regular_file(*iter))
+                    std::error_code                           ec, ec2;
+                    for(std::filesystem::directory_iterator iter{std::filesystem::path(shader_cache_dir + shader_key_dir)}; iter != end && !ec2; iter.increment(ec2))
+                        if(is_regular_file(*iter, ec))
                         {
                             if(iter->path().extension() == ".bytecode")
                                 bytecode_files.emplace_back(*iter);
@@ -9936,18 +9938,18 @@ private:
                         }
                     if(bytecode_files.size() > max_cached_files)
                     {
-                        std::sort(bytecode_files.begin(), bytecode_files.end(), [](const std::filesystem::path &a, const std::filesystem::path &b) {
-                            return last_write_time(a) > last_write_time(b); });
+                        std::sort(bytecode_files.begin(), bytecode_files.end(), [&ec](const std::filesystem::path &a, const std::filesystem::path &b) {
+                            return last_write_time(a, ec) > last_write_time(b, ec); });
                         for(size_t i = max_cached_files; i < bytecode_files.size(); ++i)
-                            std::filesystem::remove(bytecode_files[i]);
+                            std::filesystem::remove(bytecode_files[i], ec);
                     }
                     if (reflection_files.size() > max_cached_files)
                     {
                         std::sort(reflection_files.begin(), reflection_files.end(),
-                            [](std::filesystem::path const &a, std::filesystem::path const &b) {
-                                return last_write_time(a) > last_write_time(b); });
+                            [&ec](std::filesystem::path const &a, std::filesystem::path const &b) {
+                                return last_write_time(a, ec) > last_write_time(b, ec); });
                         for(size_t i = max_cached_files; i < reflection_files.size(); ++i)
-                            std::filesystem::remove(reflection_files[i]);
+                            std::filesystem::remove(reflection_files[i], ec);
                     }
                 }
             }


### PR DESCRIPTION
This adds locking around filesystem ops when writing shader cache and pdbs to avoid conflicts with multiple threads