### PR TITLE
Fix compaction completion status check

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -89,8 +89,6 @@ class GfxInternal
 {
     GFX_NON_COPYABLE(GfxInternal);
 
-	uint64_t finish_calls_counter_ = 0;
-
     HWND window_ = {};
     uint32_t window_width_ = 0;
     uint32_t window_height_ = 0;
@@ -479,8 +477,7 @@ class GfxInternal
             GfxBuffer bvh_buffer_ = {};
             GfxBuffer bvh_compact_size_buffer_ = {};
             GfxBuffer bvh_compact_size_readback_buffer_ = {};
-			uint64_t finish_calls_state = 0; // Used to detect whether `finish()` was called in between build & compact operations
-			uint64_t bvh_data_size_ = 0;
+            uint64_t bvh_data_size_ = 0;
             uint32_t index_stride_ = 0;
             GfxBuffer index_buffer_ = {};
             uint32_t vertex_stride_ = 0;
@@ -499,7 +496,6 @@ class GfxInternal
             GfxBuffer bvh_buffer_ = {};
             GfxBuffer bvh_compact_size_buffer_ = {};
             GfxBuffer bvh_compact_size_readback_buffer_ = {};
-			uint64_t finish_calls_state = 0; // Used to detect whether `finish()` was called in between build & compact operations
             uint64_t bvh_data_size_ = 0;
             uint32_t procedural_stride_ = 0;
             GfxBuffer procedural_buffer_ = {};
@@ -507,6 +503,7 @@ class GfxInternal
         }
         procedural_;
     };
+    GfxArray<uint32_t> raytracing_primitive_compaction_indices_;
     GfxArray<RaytracingPrimitive> raytracing_primitives_;
     GfxHandles raytracing_primitive_handles_;
 
@@ -2725,15 +2722,15 @@ public:
         return buildRaytracingPrimitive(raytracing_primitive, gfx_raytracing_primitive, false);
     }
 
-	GfxResult compactRaytracingPrimitive(GfxRaytracingPrimitive const& raytracing_primitive)
-	{
-		if(dxr_device_ == nullptr)
-			return kGfxResult_InvalidOperation; // avoid spamming console output
-		if(!raytracing_primitive_handles_.has_handle(raytracing_primitive.handle))
-			return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot compact geometry of an invalid raytracing primitive object");
-		RaytracingPrimitive& gfx_raytracing_primitive = raytracing_primitives_[raytracing_primitive];
-		return compactRaytracingPrimitive(gfx_raytracing_primitive);
-	}
+    GfxResult compactRaytracingPrimitive(GfxRaytracingPrimitive const &raytracing_primitive)
+    {
+        if(dxr_device_ == nullptr)
+            return kGfxResult_InvalidOperation; // avoid spamming console output
+        if(!raytracing_primitive_handles_.has_handle(raytracing_primitive.handle))
+            return GFX_SET_ERROR(kGfxResult_InvalidParameter, "Cannot compact geometry of an invalid raytracing primitive object");
+        RaytracingPrimitive &gfx_raytracing_primitive = raytracing_primitives_[raytracing_primitive];
+        return compactRaytracingPrimitive(raytracing_primitive, gfx_raytracing_primitive);
+    }
 
     GfxResult setRaytracingPrimitiveTransform(GfxRaytracingPrimitive const &raytracing_primitive, float const *row_major_4x4_transform)
     {
@@ -4870,6 +4867,9 @@ public:
             decayResourceState();
         }
         constant_buffer_pool_cursors_[fence_index_] = 0;
+        for(uint32_t i = 0; i < raytracing_primitive_compaction_indices_.size(); ++i)
+            if(raytracing_primitive_compaction_indices_.data()[i] == fence_index_)
+                raytracing_primitive_compaction_indices_.data()[i] = 0xFFFFFFFFu;
         resetState();   // re-install state
         return runGarbageCollection();
     }
@@ -4884,10 +4884,10 @@ public:
         GFX_TRY(sync());    // make sure GPU has gone through all pending work
         command_allocators_[fence_index_]->Reset();
         command_list_->Reset(command_allocators_[fence_index_], nullptr);
+        memset(raytracing_primitive_compaction_indices_.data(), 0xFFu, raytracing_primitive_compaction_indices_.size() * sizeof(uint32_t));
         resetState();   // re-install state
         decayResourceState();
-		finish_calls_counter_++;
-		return kGfxResult_NoError;
+        return kGfxResult_NoError;
     }
 
     inline ID3D12Device *getDevice() const
@@ -7510,84 +7510,84 @@ private:
         return kGfxResult_NoError;
     }
 
-	GfxResult compactRaytracingPrimitiveTriangles(RaytracingPrimitive& gfx_raytracing_primitive)
-	{
-		constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
-		bool const allow_compaction = (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
-		if(!allow_compaction)
-			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
-		if(gfx_raytracing_primitive.procedural_.finish_calls_state >= finish_calls_counter_)
-			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet. Please, call `gfxFinish()` and try again");
-		Buffer& dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
-		D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
-		memcpy(&compact_size_desc, dst.data_, compact_size);
-		const size_t old_size = gfx_raytracing_primitive.triangles_.bvh_buffer_.getSize();
-		if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
-		{
-			GFX_SET_ERROR(kGfxResult_InternalError, "Can't readback compacted AS size. Possible sync issue.");
-			return kGfxResult_InternalError; // Should we return an error here? Or do we just continue normally?
-		}
-		GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
-		Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
-		Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.triangles_.bvh_buffer_];
-		gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.triangles_.bvh_buffer_.getName());
-		SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
-		D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
-		D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
-		dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
-		destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_buffer_);
-		gfx_raytracing_primitive.triangles_.bvh_buffer_ = gfx_compacted_bvh_buffer;
-		return kGfxResult_NoError;
-	}
+    GfxResult compactRaytracingPrimitiveTriangles(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive)
+    {
+        constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
+        bool const allow_compaction = (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
+        if(!allow_compaction)
+            return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
+        if(!raytracing_primitive_compaction_indices_.has(raytracing_primitive) || raytracing_primitive_compaction_indices_[raytracing_primitive] != 0xFFFFFFFFu)
+            return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet");
+        Buffer &dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
+        memcpy(&compact_size_desc, dst.data_, compact_size);
+        size_t const old_size = gfx_raytracing_primitive.triangles_.bvh_buffer_.getSize();
+        if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+        {
+            GFX_SET_ERROR(kGfxResult_InternalError, "Can't readback compacted AS size. Possible sync issue.");
+            return kGfxResult_InternalError; // Should we return an error here? Or do we just continue normally?
+        }
+        GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+        Buffer &compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
+        Buffer &orig_bvh = buffers_[gfx_raytracing_primitive.triangles_.bvh_buffer_];
+        gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.triangles_.bvh_buffer_.getName());
+        SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
+        D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
+        D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
+        dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
+        destroyBuffer(gfx_raytracing_primitive.triangles_.bvh_buffer_);
+        gfx_raytracing_primitive.triangles_.bvh_buffer_ = gfx_compacted_bvh_buffer;
+        return kGfxResult_NoError;
+    }
 
-	GfxResult compactRaytracingPrimitiveProcedural(RaytracingPrimitive& gfx_raytracing_primitive)
-	{
-		constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
-		bool const allow_compaction = (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
-		if(!allow_compaction)
-			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
-		if(gfx_raytracing_primitive.procedural_.finish_calls_state >= finish_calls_counter_)
-			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet. Please, call `gfxFinish()` and try again");
-		Buffer& dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
-		D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
-		memcpy(&compact_size_desc, dst.data_, compact_size);
-		const size_t old_size = gfx_raytracing_primitive.procedural_.bvh_buffer_.getSize();
-		if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
-		{
-			GFX_SET_ERROR(kGfxResult_InternalError, "Can't readback compacted AS size. Possible sync issue.");
-			return kGfxResult_InternalError; // Should we return an error here? Or do we just continue normally?
-		}
-		GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
-		Buffer& compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
-		Buffer& orig_bvh = buffers_[gfx_raytracing_primitive.procedural_.bvh_buffer_];
-		gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.procedural_.bvh_buffer_.getName());
-		SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
-		D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
-		D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
-		dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
-		destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_buffer_);
-		gfx_raytracing_primitive.procedural_.bvh_buffer_ = gfx_compacted_bvh_buffer;
-		return kGfxResult_NoError;
-	}
+    GfxResult compactRaytracingPrimitiveProcedural(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive)
+    {
+        constexpr size_t compact_size = sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC);
+        bool const allow_compaction = (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
+        if(!allow_compaction)
+            return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
+        if(!raytracing_primitive_compaction_indices_.has(raytracing_primitive) || raytracing_primitive_compaction_indices_[raytracing_primitive] != 0xFFFFFFFFu)
+            return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet");
+        Buffer &dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
+        memcpy(&compact_size_desc, dst.data_, compact_size);
+        size_t const old_size = gfx_raytracing_primitive.procedural_.bvh_buffer_.getSize();
+        if(compact_size_desc.CompactedSizeInBytes == 0 || compact_size_desc.CompactedSizeInBytes > old_size)
+        {
+            GFX_SET_ERROR(kGfxResult_InternalError, "Can't readback compacted AS size. Possible sync issue.");
+            return kGfxResult_InternalError; // Should we return an error here? Or do we just continue normally?
+        }
+        GfxBuffer gfx_compacted_bvh_buffer = createBuffer(compact_size_desc.CompactedSizeInBytes, nullptr, kGfxCpuAccess_None, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+        Buffer &compacted_bvh_buffer = buffers_[gfx_compacted_bvh_buffer];
+        Buffer &orig_bvh = buffers_[gfx_raytracing_primitive.procedural_.bvh_buffer_];
+        gfx_compacted_bvh_buffer.setName(gfx_raytracing_primitive.procedural_.bvh_buffer_.getName());
+        SetObjectName(compacted_bvh_buffer, gfx_compacted_bvh_buffer.getName());
+        D3D12_GPU_VIRTUAL_ADDRESS src_address = orig_bvh.resource_->GetGPUVirtualAddress() + orig_bvh.data_offset_;
+        D3D12_GPU_VIRTUAL_ADDRESS dst_address = compacted_bvh_buffer.resource_->GetGPUVirtualAddress() + compacted_bvh_buffer.data_offset_;
+        dxr_command_list_->CopyRaytracingAccelerationStructure(dst_address, src_address, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT);
+        destroyBuffer(gfx_raytracing_primitive.procedural_.bvh_buffer_);
+        gfx_raytracing_primitive.procedural_.bvh_buffer_ = gfx_compacted_bvh_buffer;
+        return kGfxResult_NoError;
+    }
 
-	GfxResult compactRaytracingPrimitive(RaytracingPrimitive& gfx_raytracing_primitive)
-	{
-		switch(gfx_raytracing_primitive.type_)
-		{
-		case RaytracingPrimitive::kType_Triangles:
-			GFX_TRY(compactRaytracingPrimitiveTriangles(gfx_raytracing_primitive));
-			break;
-		case RaytracingPrimitive::kType_Instance:
-			return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot compact an instance raytracing primitive");
-		case RaytracingPrimitive::kType_Procedural:
-			GFX_TRY(compactRaytracingPrimitiveProcedural(gfx_raytracing_primitive));
-			break;
-		default:
-			GFX_ASSERTMSG(0, "An invalid raytracing primitive type was supplied");
-			break;
-		}
-		return kGfxResult_NoError;
-	}
+    GfxResult compactRaytracingPrimitive(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive)
+    {
+        switch(gfx_raytracing_primitive.type_)
+        {
+        case RaytracingPrimitive::kType_Triangles:
+            GFX_TRY(compactRaytracingPrimitiveTriangles(raytracing_primitive, gfx_raytracing_primitive));
+            break;
+        case RaytracingPrimitive::kType_Instance:
+            return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Cannot compact an instance raytracing primitive");
+        case RaytracingPrimitive::kType_Procedural:
+            GFX_TRY(compactRaytracingPrimitiveProcedural(raytracing_primitive, gfx_raytracing_primitive));
+            break;
+        default:
+            GFX_ASSERTMSG(0, "An invalid raytracing primitive type was supplied");
+            break;
+        }
+        return kGfxResult_NoError;
+    }
 
     GfxResult buildRaytracingPrimitiveTriangles(GfxRaytracingPrimitive const &raytracing_primitive, RaytracingPrimitive &gfx_raytracing_primitive, bool update)
     {
@@ -7711,19 +7711,19 @@ private:
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC postbuild_info = {};
         if(allow_compaction)
         {
-            Buffer& compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
+            Buffer &compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
             postbuild_info.DestBuffer = compact_size_buffer.resource_->GetGPUVirtualAddress();
             postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
         }
         dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, allow_compaction ? 1 : 0, allow_compaction ? &postbuild_info : nullptr);
         if(allow_compaction)
         {
-            Buffer& dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
-            Buffer& src = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
+            Buffer &dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
+            Buffer &src = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
             transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
             submitPipelineBarriers();
             dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
-			gfx_raytracing_primitive.triangles_.finish_calls_state = finish_calls_counter_;
+            raytracing_primitive_compaction_indices_[raytracing_primitive] = fence_index_;
         }
         return kGfxResult_NoError;
     }
@@ -7801,7 +7801,7 @@ private:
                 // We could pass `D3D12_RESOURCE_STATE_UNORDERED_ACCESS` to `createBuffer` directly,
                 // but then DX12 spams warnings about "Ignoring InitialState D3D12_RESOURCE_STATE_UNORDERED_ACCESS".
                 // So, in order to suppress them, we do this.
-                Buffer& buffer = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_];
+                Buffer &buffer = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_];
                 transitionResource(buffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, kTransitionType_Implicit);
             }
         }
@@ -7835,20 +7835,20 @@ private:
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC postbuild_info = {};
         if(allow_compaction)
         {
-            Buffer& compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
+            Buffer &compact_size_buffer = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_buffer_];
             postbuild_info.DestBuffer = compact_size_buffer.resource_->GetGPUVirtualAddress();
             postbuild_info.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE;
         }
         dxr_command_list_->BuildRaytracingAccelerationStructure(&build_desc, allow_compaction ? 1 : 0, allow_compaction ? &postbuild_info : nullptr);
         if(allow_compaction)
         {
-            Buffer& dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
-            Buffer& src = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_];
+            Buffer &dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
+            Buffer &src = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_buffer_];
             transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
             submitPipelineBarriers();
             dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
-			gfx_raytracing_primitive.triangles_.finish_calls_state = finish_calls_counter_;
-		}
+            raytracing_primitive_compaction_indices_[raytracing_primitive] = fence_index_;
+        }
         return kGfxResult_NoError;
     }
 
@@ -10672,9 +10672,9 @@ GfxResult gfxRaytracingPrimitiveBuildProcedural(GfxContext context, GfxRaytracin
 
 GfxResult gfxRaytracingPrimitiveCompact(GfxContext context, GfxRaytracingPrimitive raytracing_primitive)
 {
-	GfxInternal* gfx = GfxInternal::GetGfx(context);
-	if (!gfx) return kGfxResult_InvalidParameter;
-	return gfx->compactRaytracingPrimitive(raytracing_primitive);
+    GfxInternal *gfx = GfxInternal::GetGfx(context);
+    if(!gfx) return kGfxResult_InvalidParameter;
+    return gfx->compactRaytracingPrimitive(raytracing_primitive);
 }
 
 GfxResult gfxRaytracingPrimitiveSetTransform(GfxContext context, GfxRaytracingPrimitive raytracing_primitive, float const *row_major_4x4_transform)

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -7727,7 +7727,7 @@ private:
             transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
             submitPipelineBarriers();
             dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
-            raytracing_primitive_compaction_indices_[raytracing_primitive] = fence_index_;
+            raytracing_primitive_compaction_indices_.insert(raytracing_primitive, fence_index_);
         }
         return kGfxResult_NoError;
     }
@@ -7851,7 +7851,7 @@ private:
             transitionResource(src, D3D12_RESOURCE_STATE_COPY_SOURCE, kTransitionType_Implicit);
             submitPipelineBarriers();
             dxr_command_list_->CopyBufferRegion(dst.resource_, dst.data_offset_, src.resource_, src.data_offset_, compact_size);
-            raytracing_primitive_compaction_indices_[raytracing_primitive] = fence_index_;
+            raytracing_primitive_compaction_indices_.insert(raytracing_primitive, fence_index_);
         }
         return kGfxResult_NoError;
     }

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -2636,6 +2636,8 @@ public:
             }
         }
         collect(gfx_raytracing_primitive);  // release resources
+        if(raytracing_primitive_compaction_indices_.has(raytracing_primitive))
+            raytracing_primitive_compaction_indices_.erase(raytracing_primitive);
         raytracing_primitives_.erase(raytracing_primitive); // destroy raytracing primitive
         raytracing_primitive_handles_.free_handle(raytracing_primitive.handle);
         return kGfxResult_NoError;
@@ -7516,7 +7518,8 @@ private:
         bool const allow_compaction = (gfx_raytracing_primitive.triangles_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
         if(!allow_compaction)
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
-        if(!raytracing_primitive_compaction_indices_.has(raytracing_primitive) || raytracing_primitive_compaction_indices_[raytracing_primitive] != 0xFFFFFFFFu)
+        uint32_t const *raytracing_primitive_compaction_index = raytracing_primitive_compaction_indices_.at(raytracing_primitive);
+        if(raytracing_primitive_compaction_index == nullptr || *raytracing_primitive_compaction_index != 0xFFFFFFFFu)
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet");
         Buffer &dst = buffers_[gfx_raytracing_primitive.triangles_.bvh_compact_size_readback_buffer_];
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};
@@ -7546,7 +7549,8 @@ private:
         bool const allow_compaction = (gfx_raytracing_primitive.procedural_.build_flags_ & kGfxBuildRaytracingPrimitiveFlag_Compact) != 0;
         if(!allow_compaction)
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Compaction is not allowed for this primitive");
-        if(!raytracing_primitive_compaction_indices_.has(raytracing_primitive) || raytracing_primitive_compaction_indices_[raytracing_primitive] != 0xFFFFFFFFu)
+        uint32_t const *raytracing_primitive_compaction_index = raytracing_primitive_compaction_indices_.at(raytracing_primitive);
+        if(raytracing_primitive_compaction_index == nullptr || *raytracing_primitive_compaction_index != 0xFFFFFFFFu)
             return GFX_SET_ERROR(kGfxResult_InvalidOperation, "Post-build information is not available yet");
         Buffer &dst = buffers_[gfx_raytracing_primitive.procedural_.bvh_compact_size_readback_buffer_];
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC compact_size_desc{};


### PR DESCRIPTION
This PR fixes the invalid completion check used in the [sshikhali/bvh_compaction](https://github.com/gboisse/gfx/tree/sshikhali/bvh_compaction) branch (PR https://github.com/gboisse/gfx/pull/213).

The issue (as raised by @maoliver-amd: https://github.com/gboisse/gfx/pull/213#discussion_r3560520755) is that both calling `gfxFinish()` once and `gfxFrame()` enough times (i.e., at least `max_frames_in_flight_` times) guarantees that the GPU has executed the submitted command list.

The previous implementation was only verifying that `gfxFinish()` was being called, this one allows for the asynchronous version.
