### PR TITLE
Fix broken indexing logic in decayResourceState()

### DIFF
--- a/gfx.cpp
+++ b/gfx.cpp
@@ -4884,33 +4884,27 @@ public:
     {
         for(uint32_t i = 0; i < buffers_.size(); ++i)
         {
-            auto *buffer = buffers_.at(i);
-            if(buffer != nullptr && buffer->initial_resource_state_ == D3D12_RESOURCE_STATE_COMMON && !*buffer->transitioned_ && (*buffer->resource_state_ & D3D12_RESOURCE_STATE_GENERIC_READ) == *buffer->resource_state_)
-                *buffer->resource_state_ = D3D12_RESOURCE_STATE_COMMON;
+            Buffer &buffer = buffers_.data()[i];
+            if(buffer.initial_resource_state_ == D3D12_RESOURCE_STATE_COMMON && !*buffer.transitioned_ && (*buffer.resource_state_ & D3D12_RESOURCE_STATE_GENERIC_READ) == *buffer.resource_state_)
+                *buffer.resource_state_ = D3D12_RESOURCE_STATE_COMMON;
         }
         for(uint32_t i = 0; i < textures_.size(); ++i)
         {
-            auto *texture = textures_.at(i);
-            if(texture != nullptr && !texture->transitioned_ && (texture->resource_state_ & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE) == texture->resource_state_)
-                texture->resource_state_ = D3D12_RESOURCE_STATE_COMMON;
+            Texture &texture = textures_.data()[i];
+            if(!texture.transitioned_ && (texture.resource_state_ & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE) == texture.resource_state_)
+                texture.resource_state_ = D3D12_RESOURCE_STATE_COMMON;
         }
         if(dbg_command_list_ != nullptr)
         {
             for(uint32_t i = 0; i < buffers_.size(); ++i)
             {
-                auto *buffer = buffers_.at(i);
-                if(buffer != nullptr)
-                {
-                    dbg_command_list_->AssertResourceState(buffer->resource_, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, *buffer->resource_state_);
-                }
+                Buffer const &buffer = buffers_.data()[i];
+                dbg_command_list_->AssertResourceState(buffer.resource_, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, *buffer.resource_state_);
             }
             for(uint32_t i = 0; i < textures_.size(); ++i)
             {
-                auto *texture = textures_.at(i);
-                if(texture != nullptr)
-                {
-                    dbg_command_list_->AssertResourceState(texture->resource_, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, texture->resource_state_);
-                }
+                Texture const &texture = textures_.data()[i];
+                dbg_command_list_->AssertResourceState(texture.resource_, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, texture.resource_state_);
             }
         }
     }


### PR DESCRIPTION
The iteration over buffers and textures was broken inside the implementation of `decayResourceState()`.

This is probably a bit (too?) subtle; but `GfxArray<>` maintains effectively two representations:
- A (conceptually) sparse array that can be indexed with stable indices (referred to as `index` in the code), using `packed_indices_` to perform the indirection.
- The actual storage (i.e., `data_`) kept compacted at all times.

`size()` refers to the size of the compacted data, while `capacity()` refers to the "size of the sparse array" (or the size of `packed_indices_` typically).

So when iterating based on the `size()` of the array such as here:
```
for(uint32_t i = 0; i < buffers_.size(); ++i)
```

One cannot rely on the standard indexing methods (such as `operator []` or `at()`) as those expect the stable indices, not the "compacted ones".

Instead, we simply get the pointer to the compacted array (i.e., `data()`) and address it as we would any standard C array (since it is guaranteed to be kept compacted at all times - which is the whole point of the data structure really).
